### PR TITLE
AB#13222 Configure EF export names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 [Bb]in/
 [Oo]bj/
 TestResults/
+
+# Local SpecKit tooling and generated workflow files
+.specify/
+.speckitcommands/
+specs/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Note that the auto-creation of a database and schema only works with LocalDB in 
 1. Full-feature ER diagrams
 1. Comments per table and column
 1. Creation of SQL DDL scripts based on the data model (full script only, no migrations)
+1. Export of EF classes and a DbContext with configurable namespace and context name
 1. Save and load models from a database
 1. The DB connection is based on Entity Framework Core, so supports LocalDB (for development), MSSQL, PostgreSQL, etc.
 1. Data model versioning

--- a/WwwSqlDesigner.Tests/EfExportTests.cs
+++ b/WwwSqlDesigner.Tests/EfExportTests.cs
@@ -1,0 +1,154 @@
+using System.Xml;
+using System.Xml.Xsl;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WwwSqlDesigner.Tests;
+
+[TestClass]
+public class EfExportTests
+{
+    private static string Transform(string modelXml, XsltArgumentList? parameters = null)
+    {
+        var model = new XmlDocument();
+        model.LoadXml(modelXml);
+        var transform = new XslCompiledTransform();
+        transform.Load(Path.Combine(AppContext.BaseDirectory, "TestData", "ef-output.xsl"));
+        using var output = new StringWriter(System.Globalization.CultureInfo.InvariantCulture);
+        transform.Transform(model, parameters, output);
+        return output.ToString();
+    }
+
+    [TestMethod]
+    public void EfExportMapsSqlTypesAndRelationships()
+    {
+        var model = new XmlDocument();
+        model.LoadXml("""
+            <sql>
+              <datatypes db="mssql" />
+              <table name="parent table">
+                <row name="Id" null="0"><datatype>int</datatype></row>
+                <row name="External Id" null="0"><datatype>uniqueidentifier</datatype></row>
+                <row name="Payload" null="1"><datatype>varbinary(32)</datatype></row>
+                <key type="PRIMARY"><part>Id</part></key>
+              </table>
+              <table name="Child Table">
+                <row name="Parent Id" null="0">
+                  <datatype>int</datatype>
+                  <relation table="parent table" row="Id" />
+                </row>
+                <row name="Description field" null="1"><datatype>nvarchar(100)</datatype></row>
+                <row name="Parent External Id" null="0">
+                  <datatype>uniqueidentifier</datatype>
+                  <relation table="parent table" row="External Id" />
+                </row>
+              </table>
+            </sql>
+            """);
+
+        var transform = new XslCompiledTransform();
+        transform.Load(Path.Combine(AppContext.BaseDirectory, "TestData", "ef-output.xsl"));
+
+        using var output = new StringWriter(System.Globalization.CultureInfo.InvariantCulture);
+        transform.Transform(model, null, output);
+        var generated = output.ToString();
+
+        StringAssert.Contains(generated, "using System;");
+        StringAssert.Contains(generated, "public int Id { get; set; }");
+        StringAssert.Contains(generated, "public Guid External_Id { get; set; }");
+        StringAssert.Contains(generated, "public byte[]? Payload { get; set; }");
+        StringAssert.Contains(generated, "public string? Description_field { get; set; }");
+        StringAssert.Contains(generated, "public DbSet<parent_table> parent_tables");
+        StringAssert.Contains(generated, "HasKey(e => new { e.Id })");
+        StringAssert.Contains(generated, "HasOne<parent_table>().WithMany().HasForeignKey(e => e.Parent_Id)");
+        StringAssert.Contains(generated, "HasPrincipalKey(p => p.External_Id)");
+        Assert.IsFalse(generated.Contains("public  ", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void EfExportUsesConfiguredNamespaceAndContext()
+    {
+        var model = new XmlDocument();
+        model.LoadXml("<sql><datatypes db=\"mssql\" /><table name=\"Item\"><row name=\"Id\" null=\"0\"><datatype>int</datatype></row></table></sql>");
+
+        var transform = new XslCompiledTransform();
+        transform.Load(Path.Combine(AppContext.BaseDirectory, "TestData", "ef-output.xsl"));
+        var parameters = new XsltArgumentList();
+        parameters.AddParam("namespace", "", "Example.Models");
+        parameters.AddParam("context", "", "ExampleContext");
+
+        using var output = new StringWriter(System.Globalization.CultureInfo.InvariantCulture);
+        transform.Transform(model, parameters, output);
+        var generated = output.ToString();
+
+        StringAssert.Contains(generated, "namespace Example.Models");
+        StringAssert.Contains(generated, "public class ExampleContext : DbContext");
+        StringAssert.Contains(generated, "ExampleContext(DbContextOptions<ExampleContext> options)");
+    }
+
+    [TestMethod]
+    public void EfExportUsesStableDefaults()
+    {
+        var model = new XmlDocument();
+        model.LoadXml("<sql><datatypes db=\"mssql\" /></sql>");
+
+        var transform = new XslCompiledTransform();
+        transform.Load(Path.Combine(AppContext.BaseDirectory, "TestData", "ef-output.xsl"));
+        using var output = new StringWriter(System.Globalization.CultureInfo.InvariantCulture);
+        transform.Transform(model, null, output);
+        var generated = output.ToString();
+
+        StringAssert.Contains(generated, "namespace WwwSqlDesigner.Data");
+        StringAssert.Contains(generated, "public class ApplicationDbContext : DbContext");
+    }
+
+    [TestMethod]
+    public void EfExportProducesCompileReadyIdentifiersAndDeterministicCollisions()
+    {
+        var generated = Transform("""
+            <sql>
+              <datatypes db="mssql" />
+              <table name="2024 Orders#">
+                <row name="Event#Id" null="0"><datatype>uniqueidentifier</datatype></row>
+                <row name="Line Item" null="0"><datatype>int</datatype></row>
+                <row name="Line-Item" null="0"><datatype>int</datatype></row>
+                <key type="PRIMARY"><part>Line-Item</part></key>
+              </table>
+              <table name="2024 Orders!"><row name="Id" null="0"><datatype>int</datatype></row></table>
+            </sql>
+            """);
+
+        StringAssert.Contains(generated, "public class _2024_Orders_");
+        StringAssert.Contains(generated, "public class _2024_Orders__2");
+        StringAssert.Contains(generated, "public Guid Event_Id { get; set; }");
+        StringAssert.Contains(generated, "public int Line_Item_2 { get; set; }");
+        StringAssert.Contains(generated, "HasKey(e => new { e.Line_Item_2 })");
+    }
+
+    [TestMethod]
+    public void EfExportReservesTheConfiguredContextName()
+    {
+        var parameters = new XsltArgumentList();
+        parameters.AddParam("context", "", "ExampleContext");
+        var generated = Transform("""
+            <sql><datatypes db="mssql" />
+              <table name="ExampleContext"><row name="Id" null="0"><datatype>int</datatype></row></table>
+            </sql>
+            """, parameters);
+
+        StringAssert.Contains(generated, "public class ExampleContext_2");
+        StringAssert.Contains(generated, "public class ExampleContext : DbContext");
+    }
+
+    [TestMethod]
+    public void EfOptionsRejectInvalidNamesBeforePersisting()
+    {
+        var projectRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../"));
+        var options = File.ReadAllText(Path.Combine(projectRoot, "WwwSqlDesigner", "wwwroot", "js", "options.js"));
+        var window = File.ReadAllText(Path.Combine(projectRoot, "WwwSqlDesigner", "wwwroot", "js", "window.js"));
+
+        StringAssert.Contains(options, "setCustomValidity");
+        StringAssert.Contains(options, "return false;");
+        StringAssert.Contains(options, "CONFIG.CSHARP_KEYWORDS.includes");
+        StringAssert.Contains(window, "this.callback() !== false");
+    }
+}

--- a/WwwSqlDesigner.Tests/WwwSqlDesigner.Tests.csproj
+++ b/WwwSqlDesigner.Tests/WwwSqlDesigner.Tests.csproj
@@ -18,4 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="..\WwwSqlDesigner\WwwSqlDesigner.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="..\WwwSqlDesigner\wwwroot\db\ef\output.xsl" Link="TestData\ef-output.xsl" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/WwwSqlDesigner/wwwroot/db/ef/output.xsl
+++ b/WwwSqlDesigner/wwwroot/db/ef/output.xsl
@@ -1,103 +1,184 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="text" omit-xml-declaration="yes" />
+    <xsl:param name="namespace" select="'WwwSqlDesigner.Data'" />
+    <xsl:param name="context" select="'ApplicationDbContext'" />
 
-    <xsl:output method="text"/>
-
-    <!-- Define variables to store data types -->
-    <xsl:variable name="datatypes" select="//datatypes/group[@label='EntityFramework']/type"/>
-
-    <!-- Define a template to match the root element -->
-    <xsl:template match="/">
-        <!-- Start with the namespace and DbContext class -->
+    <xsl:template match="/sql">
         <xsl:text>using System;
 using Microsoft.EntityFrameworkCore;
 
-namespace MyApp.Models
+namespace </xsl:text><xsl:value-of select="$namespace" /><xsl:text>
 {
 </xsl:text>
-        <!-- Apply templates to process each table -->
-        <xsl:apply-templates select="//table"/>
-        <!-- Generate DbContext class -->
-        <xsl:text>    public class MyDbContext : DbContext
+        <xsl:apply-templates select="table" />
+        <xsl:text>
+    public class </xsl:text><xsl:value-of select="$context" /><xsl:text> : DbContext
     {
-        // DbSet properties for each table
+        public </xsl:text><xsl:value-of select="$context" /><xsl:text>(DbContextOptions&lt;</xsl:text><xsl:value-of select="$context" /><xsl:text>&gt; options) : base(options) { }
 </xsl:text>
-        <!-- Generate DbSet properties for each table -->
-        <xsl:apply-templates select="//table" mode="dbset"/>
-        <xsl:text>        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder.UseSqlServer("YourConnectionStringHere");
-        }
-
+        <xsl:apply-templates select="table" mode="dbset" />
+        <xsl:text>
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
 </xsl:text>
-        <!-- Generate Fluent API configurations for relationships -->
-        <xsl:apply-templates select="//table/row/relation"/>
+        <xsl:apply-templates select="table" mode="key" />
+        <xsl:apply-templates select="table/row/relation" mode="relation" />
         <xsl:text>        }
     }
 }
 </xsl:text>
     </xsl:template>
 
-    <!-- Define a template to match each table -->
     <xsl:template match="table">
-        <!-- Get the table name -->
-        <xsl:variable name="tableName" select="@name"/>
-        <!-- Start generating the class -->
-        <xsl:text>        public class </xsl:text>
-        <!-- Append table name to class name to ensure uniqueness -->
-        <xsl:value-of select="$tableName"/>
+        <xsl:text>    public class </xsl:text>
+        <xsl:call-template name="identifier"><xsl:with-param name="name" select="@name" /><xsl:with-param name="node" select="." /></xsl:call-template>
         <xsl:text>
-        {
+    {
 </xsl:text>
-        <!-- Apply templates to process each column in the table -->
-        <xsl:apply-templates select="row"/>
-        <xsl:text>        }
+        <xsl:apply-templates select="row" />
+        <xsl:text>    }
+
 </xsl:text>
     </xsl:template>
 
-    <!-- Define a template to match each column -->
     <xsl:template match="row">
-        <!-- Get the data type for the column -->
-        <xsl:variable name="columnName" select="@name"/>
-        <xsl:variable name="dataType" select="//datatypes/group[@label='EntityFramework']/type[@sql=current()/datatype]"/>
-        <!-- Generate property for each column -->
-        <xsl:text>            public </xsl:text>
-        <xsl:value-of select="$dataType/@label"/>
+        <xsl:variable name="type" select="translate(normalize-space(datatype), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')" />
+        <xsl:variable name="referenceType" select="contains($type, 'char') or contains($type, 'text') or contains($type, 'xml') or contains($type, 'binary') or $type = 'image' or $type = 'json' or $type = 'jsonb'" />
+        <xsl:text>        public </xsl:text>
+        <xsl:choose>
+            <xsl:when test="contains($type, 'binary') or $type = 'image'">byte[]</xsl:when>
+            <xsl:when test="$type = 'bigint' or $type = 'bigserial' or $type = 'serial8'">long</xsl:when>
+            <xsl:when test="$type = 'smallint'">short</xsl:when>
+            <xsl:when test="$type = 'tinyint'">byte</xsl:when>
+            <xsl:when test="$type = 'int' or $type = 'integer' or $type = 'serial' or $type = 'serial4'">int</xsl:when>
+            <xsl:when test="$type = 'decimal' or $type = 'numeric' or $type = 'money' or $type = 'smallmoney'">decimal</xsl:when>
+            <xsl:when test="$type = 'real'">float</xsl:when>
+            <xsl:when test="$type = 'float' or $type = 'double precision'">double</xsl:when>
+            <xsl:when test="$type = 'bit' or $type = 'bool' or $type = 'boolean'">bool</xsl:when>
+            <xsl:when test="$type = 'uniqueidentifier' or $type = 'uuid'">Guid</xsl:when>
+            <xsl:when test="$type = 'time' or $type = 'time without time zone' or $type = 'time with time zone'">TimeSpan</xsl:when>
+            <xsl:when test="$type = 'datetimeoffset' or $type = 'timestamp with time zone'">DateTimeOffset</xsl:when>
+            <xsl:when test="$type = 'date' or contains($type, 'date') or contains($type, 'timestamp')">DateTime</xsl:when>
+            <xsl:when test="$referenceType">string</xsl:when>
+            <xsl:otherwise>string</xsl:otherwise>
+        </xsl:choose>
+        <xsl:if test="@null = '1'">?</xsl:if>
         <xsl:text> </xsl:text>
-        <xsl:value-of select="$columnName"/>
-        <xsl:text> { get; set; }
+        <xsl:call-template name="identifier"><xsl:with-param name="name" select="@name" /><xsl:with-param name="node" select="." /></xsl:call-template>
+        <xsl:text> { get; set; }</xsl:text>
+        <xsl:if test="$referenceType and @null = '0'"> = null!;</xsl:if>
+        <xsl:text>
 </xsl:text>
     </xsl:template>
 
-    <!-- Define a template to generate DbSet properties -->
     <xsl:template match="table" mode="dbset">
         <xsl:text>        public DbSet&lt;</xsl:text>
-        <xsl:value-of select="@name"/>
+        <xsl:call-template name="identifier"><xsl:with-param name="name" select="@name" /><xsl:with-param name="node" select="." /></xsl:call-template>
         <xsl:text>&gt; </xsl:text>
-        <xsl:value-of select="@name"/>
-        <xsl:text>s { get; set; }
+        <xsl:call-template name="identifier"><xsl:with-param name="name" select="@name" /><xsl:with-param name="node" select="." /></xsl:call-template>
+        <xsl:text>s { get; set; } = null!;
 </xsl:text>
     </xsl:template>
 
-    <!-- Define a template to generate Fluent API configurations for relationships -->
-    <xsl:template match="relation">
-        <xsl:variable name="relatedTable" select="@table"/>
-        <xsl:variable name="tableName" select="ancestor::table/@name"/>
-        <xsl:variable name="foreignKey" select="@row"/>
-        <xsl:text>            modelBuilder.Entity&lt;</xsl:text>
-        <xsl:value-of select="$tableName"/>
-        <xsl:text>&gt;()</xsl:text>
-        <xsl:text>.HasOne(x => x.</xsl:text>
-        <xsl:value-of select="$relatedTable"/>
-        <xsl:text>).WithMany(y => y.</xsl:text>
-        <xsl:value-of select="$relatedTable"/>
-        <xsl:text>s)</xsl:text>
-        <xsl:text>.HasForeignKey(z => z.</xsl:text>
-        <xsl:value-of select="$foreignKey"/>
+    <xsl:template match="table" mode="key">
+        <xsl:apply-templates select="key[@type = 'PRIMARY']" mode="key" />
+    </xsl:template>
+
+    <xsl:template match="key" mode="key">
+        <xsl:variable name="table" select=".." />
+        <xsl:text>        modelBuilder.Entity&lt;</xsl:text>
+        <xsl:call-template name="identifier"><xsl:with-param name="name" select="$table/@name" /><xsl:with-param name="node" select="$table" /></xsl:call-template>
+        <xsl:text>&gt;().HasKey(e =&gt; new { </xsl:text>
+        <xsl:for-each select="part">
+            <xsl:variable name="partName" select="." />
+            <xsl:text>e.</xsl:text>
+            <xsl:call-template name="identifier"><xsl:with-param name="name" select="$partName" /><xsl:with-param name="node" select="$table/row[@name = $partName]" /></xsl:call-template>
+            <xsl:if test="position() != last()">, </xsl:if>
+        </xsl:for-each>
+        <xsl:text> });
+</xsl:text>
+    </xsl:template>
+
+    <xsl:template match="relation" mode="relation">
+        <xsl:variable name="sourceTable" select="ancestor::table" />
+        <xsl:variable name="targetName" select="@table" />
+        <xsl:variable name="targetTable" select="/sql/table[@name = $targetName]" />
+        <xsl:variable name="principalName" select="@row" />
+        <xsl:text>        modelBuilder.Entity&lt;</xsl:text>
+        <xsl:call-template name="identifier"><xsl:with-param name="name" select="$sourceTable/@name" /><xsl:with-param name="node" select="$sourceTable" /></xsl:call-template>
+        <xsl:text>&gt;().HasOne&lt;</xsl:text>
+        <xsl:call-template name="identifier"><xsl:with-param name="name" select="$targetName" /><xsl:with-param name="node" select="$targetTable" /></xsl:call-template>
+        <xsl:text>&gt;().WithMany().HasForeignKey(e =&gt; e.</xsl:text>
+        <xsl:call-template name="identifier"><xsl:with-param name="name" select="../@name" /><xsl:with-param name="node" select=".." /></xsl:call-template>
+        <xsl:text>).HasPrincipalKey(p =&gt; p.</xsl:text>
+        <xsl:call-template name="identifier"><xsl:with-param name="name" select="$principalName" /><xsl:with-param name="node" select="$targetTable/row[@name = $principalName]" /></xsl:call-template>
         <xsl:text>);
 </xsl:text>
     </xsl:template>
 
+    <xsl:template name="identifier">
+        <xsl:param name="name" />
+        <xsl:param name="node" select="/.." />
+        <xsl:variable name="base">
+            <xsl:call-template name="identifier-base"><xsl:with-param name="name" select="$name" /></xsl:call-template>
+        </xsl:variable>
+        <xsl:variable name="contextIdentifier">
+            <xsl:call-template name="identifier-base"><xsl:with-param name="name" select="$context" /></xsl:call-template>
+        </xsl:variable>
+        <xsl:value-of select="string($base)" />
+        <xsl:if test="count($node) &gt; 0 and (name($node) = 'table' or name($node) = 'row')">
+            <xsl:variable name="collisionCount">
+                <xsl:choose>
+                    <xsl:when test="name($node) = 'table'"><xsl:call-template name="identifier-collision-count"><xsl:with-param name="nodes" select="$node/preceding-sibling::table" /><xsl:with-param name="identifier" select="string($base)" /></xsl:call-template></xsl:when>
+                    <xsl:otherwise><xsl:call-template name="identifier-collision-count"><xsl:with-param name="nodes" select="$node/preceding-sibling::row" /><xsl:with-param name="identifier" select="string($base)" /></xsl:call-template></xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <xsl:variable name="reservedContextCount"><xsl:choose><xsl:when test="name($node) = 'table' and string($base) = string($contextIdentifier)">1</xsl:when><xsl:otherwise>0</xsl:otherwise></xsl:choose></xsl:variable>
+            <xsl:if test="number($collisionCount) + number($reservedContextCount) &gt; 0"><xsl:text>_</xsl:text><xsl:value-of select="number($collisionCount) + number($reservedContextCount) + 1" /></xsl:if>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="identifier-base">
+        <xsl:param name="name" />
+        <xsl:variable name="sanitized"><xsl:call-template name="sanitize-identifier"><xsl:with-param name="name" select="normalize-space($name)" /></xsl:call-template></xsl:variable>
+        <xsl:choose>
+            <xsl:when test="$sanitized = 'abstract' or $sanitized = 'as' or $sanitized = 'base' or $sanitized = 'bool' or $sanitized = 'break' or $sanitized = 'byte' or $sanitized = 'case' or $sanitized = 'catch' or $sanitized = 'char' or $sanitized = 'checked' or $sanitized = 'class' or $sanitized = 'const' or $sanitized = 'continue' or $sanitized = 'decimal' or $sanitized = 'default' or $sanitized = 'delegate' or $sanitized = 'do' or $sanitized = 'double' or $sanitized = 'else' or $sanitized = 'enum' or $sanitized = 'event' or $sanitized = 'explicit' or $sanitized = 'extern' or $sanitized = 'false' or $sanitized = 'finally' or $sanitized = 'fixed' or $sanitized = 'float' or $sanitized = 'for' or $sanitized = 'foreach' or $sanitized = 'goto' or $sanitized = 'if' or $sanitized = 'implicit' or $sanitized = 'in' or $sanitized = 'int' or $sanitized = 'interface' or $sanitized = 'internal' or $sanitized = 'is' or $sanitized = 'lock' or $sanitized = 'long' or $sanitized = 'namespace' or $sanitized = 'new' or $sanitized = 'null' or $sanitized = 'object' or $sanitized = 'operator' or $sanitized = 'out' or $sanitized = 'override' or $sanitized = 'params' or $sanitized = 'private' or $sanitized = 'protected' or $sanitized = 'public' or $sanitized = 'readonly' or $sanitized = 'ref' or $sanitized = 'return' or $sanitized = 'sbyte' or $sanitized = 'sealed' or $sanitized = 'short' or $sanitized = 'sizeof' or $sanitized = 'stackalloc' or $sanitized = 'static' or $sanitized = 'string' or $sanitized = 'struct' or $sanitized = 'switch' or $sanitized = 'this' or $sanitized = 'throw' or $sanitized = 'true' or $sanitized = 'try' or $sanitized = 'typeof' or $sanitized = 'uint' or $sanitized = 'ulong' or $sanitized = 'unchecked' or $sanitized = 'unsafe' or $sanitized = 'ushort' or $sanitized = 'using' or $sanitized = 'virtual' or $sanitized = 'void' or $sanitized = 'volatile' or $sanitized = 'while'">
+                <xsl:text>@</xsl:text><xsl:value-of select="$sanitized" />
+            </xsl:when>
+            <xsl:when test="string-length(string($sanitized)) = 0">Unnamed</xsl:when>
+            <xsl:otherwise>
+                <xsl:if test="contains('0123456789', substring(string($sanitized), 1, 1))">_</xsl:if>
+                <xsl:value-of select="string($sanitized)" />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="identifier-collision-count">
+        <xsl:param name="nodes" />
+        <xsl:param name="identifier" />
+        <xsl:choose>
+            <xsl:when test="count($nodes) = 0">0</xsl:when>
+            <xsl:otherwise>
+                <xsl:variable name="candidate"><xsl:call-template name="identifier-base"><xsl:with-param name="name" select="$nodes[1]/@name" /></xsl:call-template></xsl:variable>
+                <xsl:variable name="remaining"><xsl:call-template name="identifier-collision-count"><xsl:with-param name="nodes" select="$nodes[position() &gt; 1]" /><xsl:with-param name="identifier" select="$identifier" /></xsl:call-template></xsl:variable>
+                <xsl:choose>
+                    <xsl:when test="string($candidate) = $identifier"><xsl:value-of select="number($remaining) + 1" /></xsl:when>
+                    <xsl:otherwise><xsl:value-of select="$remaining" /></xsl:otherwise>
+                </xsl:choose>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="sanitize-identifier">
+        <xsl:param name="name" />
+        <xsl:if test="string-length($name) &gt; 0">
+            <xsl:variable name="character" select="substring($name, 1, 1)" />
+            <xsl:choose>
+                <xsl:when test="contains('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789', $character)"><xsl:value-of select="$character" /></xsl:when>
+                <xsl:otherwise>_</xsl:otherwise>
+            </xsl:choose>
+            <xsl:call-template name="sanitize-identifier"><xsl:with-param name="name" select="substring($name, 2)" /></xsl:call-template>
+        </xsl:if>
+    </xsl:template>
 </xsl:stylesheet>

--- a/WwwSqlDesigner/wwwroot/index.html
+++ b/WwwSqlDesigner/wwwroot/index.html
@@ -104,6 +104,14 @@
                     </td>
                 </tr>
                 <tr>
+                    <td><label id="efnamespace" for="optionefnamespace">EF namespace</label></td>
+                    <td><input type="text" size="32" id="optionefnamespace" /></td>
+                </tr>
+                <tr>
+                    <td><label id="efcontext" for="optionefcontext">EF context name</label></td>
+                    <td><input type="text" size="32" id="optionefcontext" /></td>
+                </tr>
+                <tr>
                     <td>
                         <label id="snap" for="optionsnap"></label>
                     </td>

--- a/WwwSqlDesigner/wwwroot/js/config.js
+++ b/WwwSqlDesigner/wwwroot/js/config.js
@@ -13,6 +13,20 @@ const CONFIG = {
         "ef"
     ],
     DEFAULT_DB: "mssql",
+    EF_DEFAULT_NAMESPACE: "WwwSqlDesigner.Data",
+    EF_DEFAULT_CONTEXT: "ApplicationDbContext",
+    CSHARP_KEYWORDS: [
+        "abstract", "as", "base", "bool", "break", "byte", "case", "catch",
+        "char", "checked", "class", "const", "continue", "decimal", "default",
+        "delegate", "do", "double", "else", "enum", "event", "explicit", "extern",
+        "false", "finally", "fixed", "float", "for", "foreach", "goto", "if",
+        "implicit", "in", "int", "interface", "internal", "is", "lock", "long",
+        "namespace", "new", "null", "object", "operator", "out", "override", "params",
+        "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed",
+        "short", "sizeof", "stackalloc", "static", "string", "struct", "switch", "this",
+        "throw", "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe",
+        "ushort", "using", "virtual", "void", "volatile", "while"
+    ],
 
     AVAILABLE_LOCALES: [
         "ar",

--- a/WwwSqlDesigner/wwwroot/js/io.js
+++ b/WwwSqlDesigner/wwwroot/js/io.js
@@ -294,7 +294,7 @@ SQL.IO.prototype.getXSL = function (xslPath, cb) {
     xhr.open("GET", xslPath, true);
     xhr.onreadystatechange = function () {
         if (xhr.readyState == 4 && xhr.status == 200) {
-            xslDoc = xhr.responseText;
+            const xslDoc = xhr.responseText;
             cb(null, xslDoc);
         }
     };
@@ -329,8 +329,30 @@ SQL.IO.prototype.performTransformation = function (xslDoc, xml) {
             }
             const xsl = new XSLTProcessor();
             xsl.importStylesheet(xslDoc);
+            if (this.owner.getXhrHeaders().transformation === "ef") {
+                const identifier = /^[A-Za-z_][A-Za-z0-9_]*$/;
+                const namespace = (this.owner.getOption("efnamespace") || "").trim();
+                const context = (this.owner.getOption("efcontext") || "").trim();
+                const namespaceParts = namespace.split(".");
+                const validNamespace = namespace.length > 0 && namespaceParts.every(
+                    (part) => identifier.test(part) && !CONFIG.CSHARP_KEYWORDS.includes(part)
+                );
+                const validContext = identifier.test(context) && !CONFIG.CSHARP_KEYWORDS.includes(context);
+                xsl.setParameter(
+                    null,
+                    "namespace",
+                    validNamespace ? namespace : CONFIG.EF_DEFAULT_NAMESPACE
+                );
+                xsl.setParameter(
+                    null,
+                    "context",
+                    validContext ? context : CONFIG.EF_DEFAULT_CONTEXT
+                );
+            }
             const transformedDocument = xsl.transformToDocument(xmlDoc);
-            result = transformedDocument.documentElement.textContent;
+            result = transformedDocument.documentElement
+                ? transformedDocument.documentElement.textContent
+                : transformedDocument.textContent;
         } else if (window.ActiveXObject || "ActiveXObject" in window) {
             const xmlDoc = new ActiveXObject("Microsoft.XMLDOM");
             xmlDoc.loadXML(xml);

--- a/WwwSqlDesigner/wwwroot/js/options.js
+++ b/WwwSqlDesigner/wwwroot/js/options.js
@@ -14,6 +14,8 @@ SQL.Options = function (owner) {
 SQL.Options.prototype.build = function () {
     this.dom.optionlocale = OZ.$("optionlocale");
     this.dom.optiondb = OZ.$("optiondb");
+    this.dom.optionefnamespace = OZ.$("optionefnamespace");
+    this.dom.optionefcontext = OZ.$("optionefcontext");
     this.dom.optionsnap = OZ.$("optionsnap");
     this.dom.optionpattern = OZ.$("optionpattern");
     this.dom.optionstyle = OZ.$("optionstyle");
@@ -25,6 +27,8 @@ SQL.Options.prototype.build = function () {
     let ids = [
         "language",
         "db",
+        "efnamespace",
+        "efcontext",
         "snap",
         "pattern",
         "style",
@@ -83,8 +87,46 @@ SQL.Options.prototype.build = function () {
 };
 
 SQL.Options.prototype.save = function () {
+    const identifier = /^[A-Za-z_][A-Za-z0-9_]*$/;
+    const namespace = this.dom.optionefnamespace.value.trim();
+    const context = this.dom.optionefcontext.value.trim();
+    const namespaceParts = namespace.split(".");
+    const validNamespace = !namespace || namespaceParts.every(
+        (part) => identifier.test(part) && !CONFIG.CSHARP_KEYWORDS.includes(part)
+    );
+    const validContext = !context || (
+        identifier.test(context) && !CONFIG.CSHARP_KEYWORDS.includes(context)
+    );
+
+    this.dom.optionefnamespace.setCustomValidity("");
+    this.dom.optionefcontext.setCustomValidity("");
+    if (!validNamespace) {
+        this.dom.optionefnamespace.setCustomValidity(
+            "Enter dot-separated C# identifiers for the EF namespace."
+        );
+        this.dom.optionefnamespace.reportValidity();
+        this.dom.optionefnamespace.focus();
+        return false;
+    }
+    if (!validContext) {
+        this.dom.optionefcontext.setCustomValidity(
+            "Enter a non-keyword C# identifier for the EF context name."
+        );
+        this.dom.optionefcontext.reportValidity();
+        this.dom.optionefcontext.focus();
+        return false;
+    }
+
     this.owner.setOption("locale", this.dom.optionlocale.value);
     this.owner.setOption("db", this.dom.optiondb.value);
+    this.owner.setOption(
+        "efnamespace",
+        namespace || CONFIG.EF_DEFAULT_NAMESPACE
+    );
+    this.owner.setOption(
+        "efcontext",
+        context || CONFIG.EF_DEFAULT_CONTEXT
+    );
     this.owner.setOption("snap", this.dom.optionsnap.value);
     this.owner.setOption("pattern", this.dom.optionpattern.value);
     this.owner.setOption("style", this.dom.optionstyle.value);
@@ -103,6 +145,8 @@ SQL.Options.prototype.save = function () {
 SQL.Options.prototype.click = function () {
     this.owner.window.open(_("options"), this.dom.container, this.save);
     this.dom.optionsnap.value = this.owner.getOption("snap");
+    this.dom.optionefnamespace.value = this.owner.getOption("efnamespace");
+    this.dom.optionefcontext.value = this.owner.getOption("efcontext");
     this.dom.optionpattern.value = this.owner.getOption("pattern");
     this.dom.optionhide.checked = this.owner.getOption("hide");
     this.dom.optionvector.checked = this.owner.getOption("vector");

--- a/WwwSqlDesigner/wwwroot/js/window.js
+++ b/WwwSqlDesigner/wwwroot/js/window.js
@@ -84,10 +84,9 @@ SQL.Window.prototype.key = function (e) {
 };
 
 SQL.Window.prototype.ok = function (e) {
-    if (this.callback) {
-        this.callback();
+    if (!this.callback || this.callback() !== false) {
+        this.close();
     }
-    this.close();
 };
 
 SQL.Window.prototype.close = function () {

--- a/WwwSqlDesigner/wwwroot/js/wwwsqldesigner.js
+++ b/WwwSqlDesigner/wwwroot/js/wwwsqldesigner.js
@@ -229,6 +229,10 @@ SQL.Designer.prototype.getOption = function (name) {
             return CONFIG.DEFAULT_LOCALE;
         case "db":
             return CONFIG.DEFAULT_DB;
+        case "efnamespace":
+            return CONFIG.EF_DEFAULT_NAMESPACE;
+        case "efcontext":
+            return CONFIG.EF_DEFAULT_CONTEXT;
         case "staticpath":
             return CONFIG.STATIC_PATH || "";
         case "xhrpath":

--- a/WwwSqlDesigner/wwwroot/locale/en.xml
+++ b/WwwSqlDesigner/wwwroot/locale/en.xml
@@ -81,6 +81,8 @@
     <string name="clientlocallist">List from Browser</string>
     <string name="clientsql">Generate SQL</string>
     <string name="clientef">Generate EF</string>
+    <string name="efnamespace">EF namespace</string>
+    <string name="efcontext">EF context name</string>
     <string name="backendlabel">Server backend:</string>
     <string name="serversave">Save</string>
     <string name="quicksave">Quicksave</string>


### PR DESCRIPTION
## Summary
- Add EF Core 8 export with configurable namespace and DbContext name.
- Generate EF entity, key, relationship, and type mappings from the designer model.
- Validate export naming inputs and document the workflow with regression coverage.

## Validation
- dotnet build .\WwwSqlDesigner\WwwSqlDesigner.csproj --no-restore
- dotnet test .\WwwSqlDesigner.Tests\WwwSqlDesigner.Tests.csproj --no-restore (13 passed)