### PR TITLE
AB#15375 Add named FK relationships

### DIFF
--- a/WwwSqlDesigner.Tests/Playwright/tests/relationship-names.spec.mjs
+++ b/WwwSqlDesigner.Tests/Playwright/tests/relationship-names.spec.mjs
@@ -42,7 +42,16 @@ test("names, persists, clears, and safely renders a relationship label", async (
     await expect(input).toHaveValue("has <img src=x>");
 
     await input.click();
+    expect(await input.evaluate((element) => (
+        element.selectionStart === 0 && element.selectionEnd === element.value.length
+    ))).toBe(true);
+    await input.press("Escape");
+
+    await input.dblclick();
     await expect(input).toHaveValue("has <img src=x>");
+    expect(await input.evaluate((element) => (
+        element.selectionStart === 0 && element.selectionEnd === element.value.length
+    ))).toBe(true);
     await input.press("Enter");
     await expect(input).not.toBeFocused();
     await expect(input).toHaveAttribute("readonly", "");

--- a/WwwSqlDesigner.Tests/Playwright/tests/relationship-names.spec.mjs
+++ b/WwwSqlDesigner.Tests/Playwright/tests/relationship-names.spec.mjs
@@ -1,0 +1,117 @@
+import { test, expect } from "@playwright/test";
+
+const unnamedModel = `<sql>
+  <table x="20" y="20" name="Parent"><row name="Id" null="0"><datatype>int</datatype></row><key type="PRIMARY"><part>Id</part></key></table>
+  <table x="360" y="120" name="Child"><row name="ParentId" null="0"><datatype>int</datatype><relation table="Parent" row="Id" /></row></table>
+</sql>`;
+
+async function loadModel(page, xml) {
+    await page.evaluate(async (model) => {
+        const datatypes = await fetch("db/mssql/datatypes.xml").then((response) => response.text());
+        window.DATATYPES = new DOMParser().parseFromString(datatypes, "text/xml").documentElement;
+        d.fromXML(new DOMParser().parseFromString(model, "text/xml").documentElement);
+    }, xml);
+}
+
+test("names, persists, clears, and safely renders a relationship label", async ({ page }) => {
+    await page.goto("/");
+    await loadModel(page, unnamedModel);
+
+    page.once("dialog", (dialog) => dialog.accept("  has <img src=x>  "));
+    await page.locator("svg .relation-handle").click();
+
+    const label = page.locator("svg .relation-label");
+    await expect(label).toHaveText("has <img src=x>");
+    await expect(page.locator("svg rect.relation-handle")).toHaveCount(1);
+    await expect(label.locator("img")).toHaveCount(0);
+    await expect(page.locator("#area")).toContainText("has <img src=x>");
+    expect(await label.getAttribute("transform")).toBeNull();
+    expect(await page.evaluate(() => {
+        const labelY = Number(document.querySelector("svg .relation-label").getAttribute("y"));
+        const handleY = Number(document.querySelector("svg .relation-handle").getAttribute("y")) + 12;
+        return labelY === handleY + 4;
+    })).toBe(true);
+
+    const saved = await page.evaluate(() => d.toXML());
+    expect(saved).toContain('name="has &lt;img src=x&gt;"');
+
+    await loadModel(page, saved);
+    await expect(page.locator("svg .relation-label")).toHaveText("has <img src=x>");
+
+    page.once("dialog", (dialog) => dialog.dismiss());
+    await page.locator("svg .relation-handle").click();
+    await expect(page.locator("svg .relation-label")).toHaveText("has <img src=x>");
+
+    page.once("dialog", (dialog) => dialog.accept("   "));
+    await page.locator("svg .relation-handle").click();
+    await expect(page.locator("svg .relation-label")).toHaveText("+");
+
+    await page.evaluate(() => d.relations[0].hide());
+    await expect(page.locator("svg .relation-handle")).toBeHidden();
+    await page.evaluate(() => d.relations[0].show());
+    await expect(page.locator("svg .relation-handle")).toBeVisible();
+    await page.evaluate(() => d.removeRelation(d.relations[0]));
+    await expect(page.locator("svg .relation-handle, svg .relation-label")).toHaveCount(0);
+});
+
+test("relationship labels render in non-SVG mode and do not affect exports", async ({ page }) => {
+    await page.goto("/");
+    await loadModel(page, unnamedModel);
+    const unnamedSql = await page.evaluate(async () => {
+        d.io.clientsql();
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        return d.io.dom.ta.value;
+    });
+    const unnamedEf = await page.evaluate(async () => {
+        d.io.clientef();
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        return d.io.dom.ta.value;
+    });
+
+    await loadModel(page, unnamedModel.replace('row="Id" />', 'row="Id" name="has" />'));
+    const namedSql = await page.evaluate(async () => {
+        d.io.clientsql();
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        return d.io.dom.ta.value;
+    });
+    const namedEf = await page.evaluate(async () => {
+        d.io.clientef();
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        return d.io.dom.ta.value;
+    });
+    expect(namedSql).toBe(unnamedSql);
+    expect(namedEf).toBe(unnamedEf);
+
+    await page.evaluate(() => d.setOption("vector", false));
+    await page.reload();
+    await loadModel(page, unnamedModel.replace('row="Id" />', 'row="Id" name="has" />'));
+    await expect(page.locator("#area .relation-handle")).toBeVisible();
+    await expect(page.locator("#area .relation-label")).toHaveText("has");
+});
+
+test("each relationship handle edits only its own relationship", async ({ page }) => {
+    await page.goto("/");
+    await loadModel(page, `<sql>
+      <table x="20" y="20" name="Left"><row name="Id" null="0"><datatype>int</datatype></row><key type="PRIMARY"><part>Id</part></key></table>
+      <table x="500" y="20" name="Right"><row name="Id" null="0"><datatype>int</datatype></row><key type="PRIMARY"><part>Id</part></key></table>
+      <table x="260" y="220" name="Child"><row name="ForeignId" null="0"><datatype>int</datatype><relation table="Left" row="Id" /><relation table="Right" row="Id" /></row></table>
+    </sql>`);
+
+    const handles = page.locator("svg .relation-handle");
+    await expect(handles).toHaveCount(2);
+    page.once("dialog", (dialog) => dialog.accept("left relationship"));
+    await handles.nth(0).click();
+    page.once("dialog", (dialog) => dialog.accept("right relationship"));
+    await handles.nth(1).click();
+
+    expect(await page.evaluate(() => d.relations.map((relation) => relation.name))).toEqual([
+        "left relationship",
+        "right relationship",
+    ]);
+    const labelPositions = await page.evaluate(() => d.relations.map((relation) => ({
+        labelY: Number(relation.dom.label.getAttribute("y")),
+        handleY: Number(relation.dom.handle.getAttribute("y")) + 12,
+    })));
+    expect(labelPositions[0].labelY).toBe(labelPositions[0].handleY + 4);
+    expect(labelPositions[1].labelY).toBe(labelPositions[1].handleY + 4);
+});

--- a/WwwSqlDesigner.Tests/Playwright/tests/relationship-names.spec.mjs
+++ b/WwwSqlDesigner.Tests/Playwright/tests/relationship-names.spec.mjs
@@ -17,41 +17,56 @@ test("names, persists, clears, and safely renders a relationship label", async (
     await page.goto("/");
     await loadModel(page, unnamedModel);
 
-    page.once("dialog", (dialog) => dialog.accept("  has <img src=x>  "));
-    await page.locator("svg .relation-handle").click();
+    const input = page.locator("input.relation-name-input");
+    await expect(input).toBeVisible();
+    await expect(input).toHaveValue("");
+    await expect(page.locator("svg .relation-handle")).toHaveCSS("width", "16px");
+    await expect(page.locator("svg .relation-handle")).toHaveCSS("height", "16px");
 
-    const label = page.locator("svg .relation-label");
-    await expect(label).toHaveText("has <img src=x>");
+    await input.click();
+    await expect(input).toBeVisible();
+    await expect(input).toBeFocused();
+    await expect(input).toHaveCSS("width", "24px");
+    await input.fill("  has <img src=x>  ");
+    await input.press("Enter");
+    await expect(input).not.toBeFocused();
+
+    await expect(input).toHaveValue("has <img src=x>");
     await expect(page.locator("svg rect.relation-handle")).toHaveCount(1);
-    await expect(label.locator("img")).toHaveCount(0);
-    await expect(page.locator("#area")).toContainText("has <img src=x>");
-    expect(await label.getAttribute("transform")).toBeNull();
-    expect(await page.evaluate(() => {
-        const labelY = Number(document.querySelector("svg .relation-label").getAttribute("y"));
-        const handleY = Number(document.querySelector("svg .relation-handle").getAttribute("y")) + 12;
-        return labelY === handleY + 4;
-    })).toBe(true);
+    await expect(page.locator(".relation-name-input img")).toHaveCount(0);
 
     const saved = await page.evaluate(() => d.toXML());
     expect(saved).toContain('name="has &lt;img src=x&gt;"');
 
     await loadModel(page, saved);
-    await expect(page.locator("svg .relation-label")).toHaveText("has <img src=x>");
+    await expect(input).toHaveValue("has <img src=x>");
 
-    page.once("dialog", (dialog) => dialog.dismiss());
-    await page.locator("svg .relation-handle").click();
-    await expect(page.locator("svg .relation-label")).toHaveText("has <img src=x>");
+    await input.click();
+    await expect(input).toHaveValue("has <img src=x>");
+    await input.press("Escape");
+    await expect(input).toHaveValue("has <img src=x>");
 
-    page.once("dialog", (dialog) => dialog.accept("   "));
-    await page.locator("svg .relation-handle").click();
-    await expect(page.locator("svg .relation-label")).toHaveText("+");
+    await input.click();
+    await input.fill("saved on click away");
+    await page.locator("svg").click({ position: { x: 900, y: 900 } });
+    await expect(input).not.toBeFocused();
+    await expect(input).toHaveValue("saved on click away");
+
+    await input.click();
+    await input.fill("   ");
+    await input.press("Enter");
+    await expect(input).toHaveValue("");
+    await expect(page.locator("svg .relation-handle")).toHaveCSS("width", "16px");
+    await expect(page.locator("svg .relation-handle")).toHaveCSS("height", "16px");
 
     await page.evaluate(() => d.relations[0].hide());
     await expect(page.locator("svg .relation-handle")).toBeHidden();
+    await expect(input).toBeHidden();
     await page.evaluate(() => d.relations[0].show());
     await expect(page.locator("svg .relation-handle")).toBeVisible();
+    await expect(input).toBeVisible();
     await page.evaluate(() => d.removeRelation(d.relations[0]));
-    await expect(page.locator("svg .relation-handle, svg .relation-label")).toHaveCount(0);
+    await expect(page.locator("svg .relation-handle, input.relation-name-input")).toHaveCount(0);
 });
 
 test("relationship labels render in non-SVG mode and do not affect exports", async ({ page }) => {
@@ -86,7 +101,7 @@ test("relationship labels render in non-SVG mode and do not affect exports", asy
     await page.reload();
     await loadModel(page, unnamedModel.replace('row="Id" />', 'row="Id" name="has" />'));
     await expect(page.locator("#area .relation-handle")).toBeVisible();
-    await expect(page.locator("#area .relation-label")).toHaveText("has");
+    await expect(page.locator("#area input.relation-name-input")).toHaveValue("has");
 });
 
 test("each relationship handle edits only its own relationship", async ({ page }) => {
@@ -98,20 +113,18 @@ test("each relationship handle edits only its own relationship", async ({ page }
     </sql>`);
 
     const handles = page.locator("svg .relation-handle");
+    const inputs = page.locator("input.relation-name-input");
+    const activeInput = page.locator("input.relation-name-input:not([readonly])");
     await expect(handles).toHaveCount(2);
-    page.once("dialog", (dialog) => dialog.accept("left relationship"));
-    await handles.nth(0).click();
-    page.once("dialog", (dialog) => dialog.accept("right relationship"));
-    await handles.nth(1).click();
+    await inputs.nth(0).click();
+    await activeInput.fill("left relationship");
+    await activeInput.press("Enter");
+    await inputs.nth(1).click();
+    await activeInput.fill("right relationship");
+    await activeInput.press("Enter");
 
     expect(await page.evaluate(() => d.relations.map((relation) => relation.name))).toEqual([
         "left relationship",
         "right relationship",
     ]);
-    const labelPositions = await page.evaluate(() => d.relations.map((relation) => ({
-        labelY: Number(relation.dom.label.getAttribute("y")),
-        handleY: Number(relation.dom.handle.getAttribute("y")) + 12,
-    })));
-    expect(labelPositions[0].labelY).toBe(labelPositions[0].handleY + 4);
-    expect(labelPositions[1].labelY).toBe(labelPositions[1].handleY + 4);
 });

--- a/WwwSqlDesigner.Tests/Playwright/tests/relationship-names.spec.mjs
+++ b/WwwSqlDesigner.Tests/Playwright/tests/relationship-names.spec.mjs
@@ -20,8 +20,11 @@ test("names, persists, clears, and safely renders a relationship label", async (
     const input = page.locator("input.relation-name-input");
     await expect(input).toBeVisible();
     await expect(input).toHaveValue("");
+    await expect(input).toHaveAttribute("placeholder", "+");
     await expect(page.locator("svg .relation-handle")).toHaveCSS("width", "16px");
     await expect(page.locator("svg .relation-handle")).toHaveCSS("height", "16px");
+    await expect(page.locator("svg .relation-handle")).toHaveAttribute("x");
+    await expect(page.locator("svg .relation-handle")).toHaveAttribute("y");
 
     await input.click();
     await expect(input).toBeVisible();

--- a/WwwSqlDesigner.Tests/Playwright/tests/relationship-names.spec.mjs
+++ b/WwwSqlDesigner.Tests/Playwright/tests/relationship-names.spec.mjs
@@ -43,6 +43,18 @@ test("names, persists, clears, and safely renders a relationship label", async (
 
     await input.click();
     await expect(input).toHaveValue("has <img src=x>");
+    await input.press("Enter");
+    await expect(input).not.toBeFocused();
+    await expect(input).toHaveAttribute("readonly", "");
+    expect(await input.evaluate((element) => element.selectionStart === element.selectionEnd)).toBe(true);
+
+    await input.click();
+    await page.locator("svg").click({ position: { x: 900, y: 900 } });
+    await expect(input).not.toBeFocused();
+    await expect(input).toHaveAttribute("readonly", "");
+    expect(await input.evaluate((element) => element.selectionStart === element.selectionEnd)).toBe(true);
+
+    await input.click();
     await input.press("Escape");
     await expect(input).toHaveValue("has <img src=x>");
 

--- a/WwwSqlDesigner/wwwroot/js/relation.js
+++ b/WwwSqlDesigner/wwwroot/js/relation.js
@@ -96,6 +96,7 @@ SQL.Relation = function (owner, row1, row2) {
     this.dom.input.setAttribute("class", "relation-name-input");
     this.dom.input.setAttribute("aria-label", _("relationname"));
     this.dom.input.setAttribute("autocomplete", "off");
+    this.dom.input.setAttribute("placeholder", "+");
     this.dom.input.readOnly = true;
     this.owner.dom.container.appendChild(this.dom.input);
 
@@ -255,10 +256,10 @@ SQL.Relation.prototype.redrawControl = function (x, y) {
         ? this.editingWidth
         : (hasName ? this.measureNameWidth(this.name) + 16 : 16);
     if (this.owner.vector) {
-        this.dom.handle.style.x = pointX - controlWidth / 2 + "px";
-        this.dom.handle.style.y = pointY - handleSize / 2 + "px";
-        this.dom.handle.style.width = controlWidth + "px";
-        this.dom.handle.style.height = handleSize + "px";
+        this.dom.handle.setAttribute("x", pointX - controlWidth / 2);
+        this.dom.handle.setAttribute("y", pointY - handleSize / 2);
+        this.dom.handle.setAttribute("width", controlWidth);
+        this.dom.handle.setAttribute("height", handleSize);
     } else {
         this.dom.handle.style.left = pointX - controlWidth / 2 + "px";
         this.dom.handle.style.top = pointY - handleSize / 2 + "px";

--- a/WwwSqlDesigner/wwwroot/js/relation.js
+++ b/WwwSqlDesigner/wwwroot/js/relation.js
@@ -99,13 +99,11 @@ SQL.Relation = function (owner, row1, row2) {
     this.dom.input.readOnly = true;
     this.owner.dom.container.appendChild(this.dom.input);
 
-    OZ.Event.add(this.dom.handle, "click", this.editName.bind(this));
     this.dom.input.addEventListener("click", this.editName.bind(this));
     this.dom.input.addEventListener("blur", this.finishName.bind(this, false));
     this.dom.input.addEventListener("input", this.resizeName.bind(this));
     this.dom.input.addEventListener("keydown", this.keydownName.bind(this));
     this.outsideClick = this.clickAway.bind(this);
-    document.addEventListener("pointerdown", this.outsideClick, true);
     this.redraw();
 };
 SQL.Relation._counter = 0;
@@ -166,10 +164,9 @@ SQL.Relation.prototype.editName = function (e) {
         ? this.dom.handle.getBBox()
         : { width: this.dom.handle.offsetWidth };
     this.editingWidth = Math.max(24, handleBounds.width);
-    if (!this.name) {
-        this.transitionControl();
-    }
+    this.transitionControl();
     this.editing = true;
+    document.addEventListener("pointerdown", this.outsideClick, true);
     this.dom.input.value = this.name;
     this.redraw();
     this.dom.input.focus();
@@ -201,34 +198,38 @@ SQL.Relation.prototype.finishName = function (cancel) {
     }
     this.editing = false;
     this.editingWidth = 0;
+    document.removeEventListener("pointerdown", this.outsideClick, true);
     if (!cancel) {
         this.name = this.dom.input.value.trim();
     }
-    if (!this.name) {
-        this.transitionControl();
-    }
+    this.transitionControl();
     this.redraw();
+    this.dom.input.setSelectionRange(0, 0);
     if (document.activeElement === this.dom.input) {
         this.dom.input.blur();
     }
 };
 
 SQL.Relation.prototype.transitionControl = function () {
-    const handle = this.dom.handle;
     clearTimeout(this.transitionTimeout);
-    handle.classList.add("relation-handle-transitioning");
-    this.transitionTimeout = setTimeout(function () {
-        handle.classList.remove("relation-handle-transitioning");
-    }, 120);
+    this.dom.handle.classList.add("relation-control-transitioning");
+    this.dom.input.classList.add("relation-control-transitioning");
+    this.transitionTimeout = setTimeout(this.clearControlTransition.bind(this), 120);
+};
+
+SQL.Relation.prototype.clearControlTransition = function () {
+    this.dom.handle.classList.remove("relation-control-transitioning");
+    this.dom.input.classList.remove("relation-control-transitioning");
 };
 
 SQL.Relation.prototype.resizeName = function () {
     if (this.editing) {
+        this.clearControlTransition();
         this.editingWidth = Math.max(
             24,
             this.measureNameWidth(this.dom.input.value) + 16
         );
-        this.redrawLabel(this.labelPosition[0], this.labelPosition[1]);
+        this.redrawControl(this.labelPosition[0], this.labelPosition[1]);
     }
 };
 
@@ -239,7 +240,7 @@ SQL.Relation.prototype.measureNameWidth = function (name) {
     return Math.ceil(context.measureText(name).width);
 };
 
-SQL.Relation.prototype.redrawLabel = function (x, y) {
+SQL.Relation.prototype.redrawControl = function (x, y) {
     this.labelPosition = [x, y];
     const hasName = !!this.name;
     const editing = this.editing;
@@ -265,9 +266,9 @@ SQL.Relation.prototype.redrawLabel = function (x, y) {
     }
     this.dom.input.readOnly = !editing;
     this.dom.input.style.left = pointX - controlWidth / 2 + "px";
-    this.dom.input.style.top = pointY - 12 + "px";
+    this.dom.input.style.top = pointY - handleSize / 2 + "px";
     this.dom.input.style.width = controlWidth + "px";
-    this.dom.input.style.height = "24px";
+    this.dom.input.style.height = handleSize + "px";
     this.dom.input.style.visibility = "";
 };
 
@@ -299,7 +300,7 @@ SQL.Relation.prototype.redrawNormal = function (p1, p2, half) {
         this.dom[2].style.top = p2[1] + "px";
         this.dom[2].style.width = half + "px";
     }
-    this.redrawLabel(p1[0] + half, (p1[1] + p2[1]) / 2);
+    this.redrawControl(p1[0] + half, (p1[1] + p2[1]) / 2);
 };
 
 SQL.Relation.prototype.redrawSide = function (p1, p2, x) {
@@ -321,7 +322,7 @@ SQL.Relation.prototype.redrawSide = function (p1, p2, x) {
         this.dom[2].style.top = p2[1] + "px";
         this.dom[2].style.width = Math.abs(p2[0] - x) + "px";
     }
-    this.redrawLabel(x, (p1[1] + p2[1]) / 2);
+    this.redrawControl(x, (p1[1] + p2[1]) / 2);
 };
 
 SQL.Relation.prototype.redraw = function () {

--- a/WwwSqlDesigner/wwwroot/js/relation.js
+++ b/WwwSqlDesigner/wwwroot/js/relation.js
@@ -8,6 +8,7 @@ SQL.Relation = function (owner, row1, row2) {
     this.hidden = false;
     this.relationColors = CONFIG.RELATION_COLORS;
     this.highlighted = null;
+    this.name = "";
     SQL.Visual.apply(this);
 
     this.style = SQL.Designer.getOption("style");
@@ -43,6 +44,19 @@ SQL.Relation = function (owner, row1, row2) {
         path.setAttribute("fill", "none");
         this.owner.dom.svg.appendChild(path);
         this.dom.push(path);
+        this.dom.handle = document.createElementNS(this.owner.svgNS, "rect");
+        this.dom.handle.setAttribute("class", "relation-handle");
+        this.dom.handle.setAttribute("rx", "6");
+        this.dom.handle.setAttribute("ry", "6");
+        this.dom.handle.setAttribute("fill", "#fff");
+        this.dom.handle.setAttribute("stroke", this.color);
+        this.dom.handle.setAttribute("stroke-width", "2");
+        this.dom.handle.style.cursor = "pointer";
+        this.owner.dom.svg.appendChild(this.dom.handle);
+        this.dom.label = document.createElementNS(this.owner.svgNS, "text");
+        this.dom.label.setAttribute("class", "relation-label");
+        this.dom.label.style.pointerEvents = "none";
+        this.owner.dom.svg.appendChild(this.dom.label);
     } else {
         for (let i = 0; i < 3; i++) {
             const div = OZ.DOM.elm("div", {
@@ -60,8 +74,28 @@ SQL.Relation = function (owner, row1, row2) {
             }
             this.owner.dom.container.appendChild(div);
         }
+        this.dom.handle = OZ.DOM.elm("div", {
+            position: "absolute",
+            className: "relation-handle",
+        });
+        OZ.Style.set(this.dom.handle, {
+            border: "2px solid " + this.color,
+            borderRadius: "6px",
+            backgroundColor: "#fff",
+            boxSizing: "border-box",
+            cursor: "pointer",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "0 8px",
+        });
+        this.dom.label = OZ.DOM.elm("div", { className: "relation-label" });
+        this.dom.label.style.pointerEvents = "none";
+        this.dom.handle.appendChild(this.dom.label);
+        this.owner.dom.container.appendChild(this.dom.handle);
     }
 
+    OZ.Event.add(this.dom.handle, "click", this.editName.bind(this));
     this.redraw();
 };
 SQL.Relation._counter = 0;
@@ -99,12 +133,55 @@ SQL.Relation.prototype.show = function () {
     for (let elm of this.dom) {
         elm.style.visibility = "";
     }
+    this.dom.label.style.visibility = "";
+    this.dom.handle.style.visibility = "";
 };
 
 SQL.Relation.prototype.hide = function () {
     this.hidden = true;
     for (let elm of this.dom) {
         elm.style.visibility = "hidden";
+    }
+    this.dom.label.style.visibility = "hidden";
+    this.dom.handle.style.visibility = "hidden";
+};
+
+SQL.Relation.prototype.editName = function (e) {
+    OZ.Event.prevent(e);
+    OZ.Event.stop(e);
+    const name = prompt(_("relationname"), this.name);
+    if (name === null) {
+        return;
+    }
+    this.name = name.trim();
+    this.redraw();
+};
+
+SQL.Relation.prototype.redrawLabel = function (x, y) {
+    const label = this.dom.label;
+    label.textContent = this.name || "+";
+    label.style.display = "";
+    const pointX = x;
+    const pointY = y;
+    const anchorRatio = 0.5;
+    const width = this.owner.vector
+        ? label.getComputedTextLength()
+        : label.offsetWidth;
+    const labelX = pointX - width * anchorRatio;
+    if (this.owner.vector) {
+        label.setAttribute("x", labelX);
+        label.setAttribute("y", pointY + 4);
+        label.setAttribute("text-anchor", "start");
+        label.removeAttribute("transform");
+        this.dom.handle.setAttribute("x", labelX - 8);
+        this.dom.handle.setAttribute("y", pointY - 12);
+        this.dom.handle.setAttribute("width", width + 16);
+        this.dom.handle.setAttribute("height", "24");
+    } else {
+        this.dom.handle.style.left = labelX - 8 + "px";
+        this.dom.handle.style.top = pointY - 12 + "px";
+        this.dom.handle.style.width = width + 16 + "px";
+        this.dom.handle.style.height = "24px";
     }
 };
 
@@ -136,6 +213,7 @@ SQL.Relation.prototype.redrawNormal = function (p1, p2, half) {
         this.dom[2].style.top = p2[1] + "px";
         this.dom[2].style.width = half + "px";
     }
+    this.redrawLabel(p1[0] + half, (p1[1] + p2[1]) / 2);
 };
 
 SQL.Relation.prototype.redrawSide = function (p1, p2, x) {
@@ -157,6 +235,7 @@ SQL.Relation.prototype.redrawSide = function (p1, p2, x) {
         this.dom[2].style.top = p2[1] + "px";
         this.dom[2].style.width = Math.abs(p2[0] - x) + "px";
     }
+    this.redrawLabel(x, (p1[1] + p2[1]) / 2);
 };
 
 SQL.Relation.prototype.redraw = function () {
@@ -227,6 +306,10 @@ SQL.Relation.prototype.destroy = function () {
     this.row1.removeRelation(this);
     this.row2.removeRelation(this);
     for (let elm of this.dom) {
-        elm.parentNode.removeChild(this.dom[i]);
+        elm.parentNode.removeChild(elm);
     }
+    if (this.owner.vector) {
+        this.dom.label.parentNode.removeChild(this.dom.label);
+    }
+    this.dom.handle.parentNode.removeChild(this.dom.handle);
 };

--- a/WwwSqlDesigner/wwwroot/js/relation.js
+++ b/WwwSqlDesigner/wwwroot/js/relation.js
@@ -99,7 +99,8 @@ SQL.Relation = function (owner, row1, row2) {
     this.dom.input.readOnly = true;
     this.owner.dom.container.appendChild(this.dom.input);
 
-    this.dom.input.addEventListener("click", this.editName.bind(this));
+    this.dom.input.addEventListener("focus", this.editName.bind(this));
+    this.dom.input.addEventListener("dblclick", this.selectName.bind(this));
     this.dom.input.addEventListener("blur", this.finishName.bind(this, false));
     this.dom.input.addEventListener("input", this.resizeName.bind(this));
     this.dom.input.addEventListener("keydown", this.keydownName.bind(this));
@@ -155,8 +156,6 @@ SQL.Relation.prototype.hide = function () {
 };
 
 SQL.Relation.prototype.editName = function (e) {
-    OZ.Event.prevent(e);
-    OZ.Event.stop(e);
     if (this.editing) {
         return;
     }
@@ -169,8 +168,13 @@ SQL.Relation.prototype.editName = function (e) {
     document.addEventListener("pointerdown", this.outsideClick, true);
     this.dom.input.value = this.name;
     this.redraw();
-    this.dom.input.focus();
     this.dom.input.select();
+};
+
+SQL.Relation.prototype.selectName = function () {
+    if (this.editing) {
+        this.dom.input.select();
+    }
 };
 
 SQL.Relation.prototype.keydownName = function (e) {

--- a/WwwSqlDesigner/wwwroot/js/relation.js
+++ b/WwwSqlDesigner/wwwroot/js/relation.js
@@ -9,6 +9,9 @@ SQL.Relation = function (owner, row1, row2) {
     this.relationColors = CONFIG.RELATION_COLORS;
     this.highlighted = null;
     this.name = "";
+    this.editing = false;
+    this.editingWidth = 0;
+    this.transitionTimeout = null;
     SQL.Visual.apply(this);
 
     this.style = SQL.Designer.getOption("style");
@@ -53,10 +56,6 @@ SQL.Relation = function (owner, row1, row2) {
         this.dom.handle.setAttribute("stroke-width", "2");
         this.dom.handle.style.cursor = "pointer";
         this.owner.dom.svg.appendChild(this.dom.handle);
-        this.dom.label = document.createElementNS(this.owner.svgNS, "text");
-        this.dom.label.setAttribute("class", "relation-label");
-        this.dom.label.style.pointerEvents = "none";
-        this.owner.dom.svg.appendChild(this.dom.label);
     } else {
         for (let i = 0; i < 3; i++) {
             const div = OZ.DOM.elm("div", {
@@ -89,13 +88,24 @@ SQL.Relation = function (owner, row1, row2) {
             justifyContent: "center",
             padding: "0 8px",
         });
-        this.dom.label = OZ.DOM.elm("div", { className: "relation-label" });
-        this.dom.label.style.pointerEvents = "none";
-        this.dom.handle.appendChild(this.dom.label);
         this.owner.dom.container.appendChild(this.dom.handle);
     }
 
+    this.dom.input = document.createElement("input");
+    this.dom.input.setAttribute("type", "text");
+    this.dom.input.setAttribute("class", "relation-name-input");
+    this.dom.input.setAttribute("aria-label", _("relationname"));
+    this.dom.input.setAttribute("autocomplete", "off");
+    this.dom.input.readOnly = true;
+    this.owner.dom.container.appendChild(this.dom.input);
+
     OZ.Event.add(this.dom.handle, "click", this.editName.bind(this));
+    this.dom.input.addEventListener("click", this.editName.bind(this));
+    this.dom.input.addEventListener("blur", this.finishName.bind(this, false));
+    this.dom.input.addEventListener("input", this.resizeName.bind(this));
+    this.dom.input.addEventListener("keydown", this.keydownName.bind(this));
+    this.outsideClick = this.clickAway.bind(this);
+    document.addEventListener("pointerdown", this.outsideClick, true);
     this.redraw();
 };
 SQL.Relation._counter = 0;
@@ -133,8 +143,8 @@ SQL.Relation.prototype.show = function () {
     for (let elm of this.dom) {
         elm.style.visibility = "";
     }
-    this.dom.label.style.visibility = "";
     this.dom.handle.style.visibility = "";
+    this.dom.input.style.visibility = "";
 };
 
 SQL.Relation.prototype.hide = function () {
@@ -142,47 +152,123 @@ SQL.Relation.prototype.hide = function () {
     for (let elm of this.dom) {
         elm.style.visibility = "hidden";
     }
-    this.dom.label.style.visibility = "hidden";
     this.dom.handle.style.visibility = "hidden";
+    this.dom.input.style.visibility = "hidden";
 };
 
 SQL.Relation.prototype.editName = function (e) {
     OZ.Event.prevent(e);
     OZ.Event.stop(e);
-    const name = prompt(_("relationname"), this.name);
-    if (name === null) {
+    if (this.editing) {
         return;
     }
-    this.name = name.trim();
+    const handleBounds = this.owner.vector
+        ? this.dom.handle.getBBox()
+        : { width: this.dom.handle.offsetWidth };
+    this.editingWidth = Math.max(24, handleBounds.width);
+    if (!this.name) {
+        this.transitionControl();
+    }
+    this.editing = true;
+    this.dom.input.value = this.name;
     this.redraw();
+    this.dom.input.focus();
+    this.dom.input.select();
+};
+
+SQL.Relation.prototype.keydownName = function (e) {
+    if (!this.editing && (e.key === "Enter" || e.key === " ")) {
+        this.editName(e);
+    } else if (e.key === "Enter") {
+        OZ.Event.prevent(e);
+        this.finishName(false);
+    } else if (e.key === "Escape") {
+        OZ.Event.prevent(e);
+        this.finishName(true);
+    }
+};
+
+SQL.Relation.prototype.clickAway = function (e) {
+    if (!this.editing || this.dom.input.contains(e.target) || this.dom.handle.contains(e.target)) {
+        return;
+    }
+    this.finishName(false);
+};
+
+SQL.Relation.prototype.finishName = function (cancel) {
+    if (!this.editing) {
+        return;
+    }
+    this.editing = false;
+    this.editingWidth = 0;
+    if (!cancel) {
+        this.name = this.dom.input.value.trim();
+    }
+    if (!this.name) {
+        this.transitionControl();
+    }
+    this.redraw();
+    if (document.activeElement === this.dom.input) {
+        this.dom.input.blur();
+    }
+};
+
+SQL.Relation.prototype.transitionControl = function () {
+    const handle = this.dom.handle;
+    clearTimeout(this.transitionTimeout);
+    handle.classList.add("relation-handle-transitioning");
+    this.transitionTimeout = setTimeout(function () {
+        handle.classList.remove("relation-handle-transitioning");
+    }, 120);
+};
+
+SQL.Relation.prototype.resizeName = function () {
+    if (this.editing) {
+        this.editingWidth = Math.max(
+            24,
+            this.measureNameWidth(this.dom.input.value) + 16
+        );
+        this.redrawLabel(this.labelPosition[0], this.labelPosition[1]);
+    }
+};
+
+SQL.Relation.prototype.measureNameWidth = function (name) {
+    const canvas = document.createElement("canvas");
+    const context = canvas.getContext("2d");
+    context.font = getComputedStyle(this.dom.input).font;
+    return Math.ceil(context.measureText(name).width);
 };
 
 SQL.Relation.prototype.redrawLabel = function (x, y) {
-    const label = this.dom.label;
-    label.textContent = this.name || "+";
-    label.style.display = "";
+    this.labelPosition = [x, y];
+    const hasName = !!this.name;
+    const editing = this.editing;
+    const handleSize = hasName || editing ? 24 : 16;
     const pointX = x;
     const pointY = y;
-    const anchorRatio = 0.5;
-    const width = this.owner.vector
-        ? label.getComputedTextLength()
-        : label.offsetWidth;
-    const labelX = pointX - width * anchorRatio;
+    const controlWidth = editing
+        ? this.editingWidth
+        : (hasName ? this.measureNameWidth(this.name) + 16 : 16);
     if (this.owner.vector) {
-        label.setAttribute("x", labelX);
-        label.setAttribute("y", pointY + 4);
-        label.setAttribute("text-anchor", "start");
-        label.removeAttribute("transform");
-        this.dom.handle.setAttribute("x", labelX - 8);
-        this.dom.handle.setAttribute("y", pointY - 12);
-        this.dom.handle.setAttribute("width", width + 16);
-        this.dom.handle.setAttribute("height", "24");
+        this.dom.handle.style.x = pointX - controlWidth / 2 + "px";
+        this.dom.handle.style.y = pointY - handleSize / 2 + "px";
+        this.dom.handle.style.width = controlWidth + "px";
+        this.dom.handle.style.height = handleSize + "px";
     } else {
-        this.dom.handle.style.left = labelX - 8 + "px";
-        this.dom.handle.style.top = pointY - 12 + "px";
-        this.dom.handle.style.width = width + 16 + "px";
-        this.dom.handle.style.height = "24px";
+        this.dom.handle.style.left = pointX - controlWidth / 2 + "px";
+        this.dom.handle.style.top = pointY - handleSize / 2 + "px";
+        this.dom.handle.style.width = controlWidth + "px";
+        this.dom.handle.style.height = handleSize + "px";
     }
+    if (!editing) {
+        this.dom.input.value = this.name;
+    }
+    this.dom.input.readOnly = !editing;
+    this.dom.input.style.left = pointX - controlWidth / 2 + "px";
+    this.dom.input.style.top = pointY - 12 + "px";
+    this.dom.input.style.width = controlWidth + "px";
+    this.dom.input.style.height = "24px";
+    this.dom.input.style.visibility = "";
 };
 
 SQL.Relation.prototype.redrawNormal = function (p1, p2, half) {
@@ -303,13 +389,13 @@ SQL.Relation.prototype.redraw = function () {
 };
 
 SQL.Relation.prototype.destroy = function () {
+    clearTimeout(this.transitionTimeout);
+    document.removeEventListener("pointerdown", this.outsideClick, true);
     this.row1.removeRelation(this);
     this.row2.removeRelation(this);
     for (let elm of this.dom) {
         elm.parentNode.removeChild(elm);
     }
-    if (this.owner.vector) {
-        this.dom.label.parentNode.removeChild(this.dom.label);
-    }
     this.dom.handle.parentNode.removeChild(this.dom.handle);
+    this.dom.input.parentNode.removeChild(this.dom.input);
 };

--- a/WwwSqlDesigner/wwwroot/js/row.js
+++ b/WwwSqlDesigner/wwwroot/js/row.js
@@ -417,6 +417,9 @@ SQL.Row.prototype.toXML = function () {
             relation.row1.owner.getTitle() +
             '" row="' +
             relation.row1.getTitle() +
+            (relation.name
+                ? '" name="' + SQL.escape(relation.name).replace(/"/g, "&quot;")
+                : "") +
             '" />\n';
     }
 

--- a/WwwSqlDesigner/wwwroot/js/rubberband.js
+++ b/WwwSqlDesigner/wwwroot/js/rubberband.js
@@ -9,7 +9,8 @@ SQL.Rubberband = function (owner) {
 SQL.Rubberband.prototype = Object.create(SQL.Visual.prototype);
 
 SQL.Rubberband.prototype.down = function (e) {
-    if (e.target && e.target.closest && e.target.closest(".diagram-legend")) {
+    const target = OZ.Event.target(e);
+    if (target && ((target.closest && target.closest(".diagram-legend")) || target.matches("input.relation-name-input"))) {
         return;
     }
     OZ.Event.prevent(e);

--- a/WwwSqlDesigner/wwwroot/js/wwwsqldesigner.js
+++ b/WwwSqlDesigner/wwwroot/js/wwwsqldesigner.js
@@ -410,7 +410,9 @@ SQL.Designer.prototype.fromXML = function (node) {
             continue;
         }
 
-        this.addRelation(r1, r2);
+        const relation = this.addRelation(r1, r2);
+        relation.name = rel.getAttribute("name") || "";
+        relation.redraw();
     }
 
     this.sync();

--- a/WwwSqlDesigner/wwwroot/locale/en.xml
+++ b/WwwSqlDesigner/wwwroot/locale/en.xml
@@ -25,6 +25,7 @@
     <string name="foreignconnect">Connect foreign key</string>
     <string name="foreignconnectpending">click target row</string>
     <string name="foreigndisconnect">Remove foreign key</string>
+    <string name="relationname">Enter relationship name</string>
     <string name="confirmtable">Really delete table</string>
     <string name="confirmrow">Really delete field</string>
 

--- a/WwwSqlDesigner/wwwroot/styles/material-inspired.css
+++ b/WwwSqlDesigner/wwwroot/styles/material-inspired.css
@@ -724,7 +724,7 @@ label, input, select {
     fill: #fff;
 }
 
-.relation-handle-transitioning {
+.relation-handle.relation-control-transitioning {
     transition: x 120ms ease-out, y 120ms ease-out, width 120ms ease-out, height 120ms ease-out;
 }
 
@@ -744,6 +744,10 @@ input.relation-name-input {
     line-height: 24px;
     text-align: center;
     cursor: pointer;
+}
+
+input.relation-name-input.relation-control-transitioning {
+    transition: left 120ms ease-out, top 120ms ease-out, width 120ms ease-out, height 120ms ease-out;
 }
 
 input.relation-name-input:focus {

--- a/WwwSqlDesigner/wwwroot/styles/material-inspired.css
+++ b/WwwSqlDesigner/wwwroot/styles/material-inspired.css
@@ -725,7 +725,7 @@ label, input, select {
 }
 
 .relation-handle.relation-control-transitioning {
-    transition: x 120ms ease-out, y 120ms ease-out, width 120ms ease-out, height 120ms ease-out;
+    transition: left 120ms ease-out, top 120ms ease-out, x 120ms ease-out, y 120ms ease-out, width 120ms ease-out, height 120ms ease-out;
 }
 
 input.relation-name-input {
@@ -759,4 +759,9 @@ input.relation-name-input:focus {
 
 input.relation-name-input:not([readonly]) {
     cursor: text;
+}
+
+input.relation-name-input::placeholder {
+    color: inherit;
+    opacity: 1;
 }

--- a/WwwSqlDesigner/wwwroot/styles/material-inspired.css
+++ b/WwwSqlDesigner/wwwroot/styles/material-inspired.css
@@ -713,4 +713,21 @@ label, input, select {
 .diagram-legend-timestamp > span.empty {
     opacity: .7;
     font-style: italic;
+.relation-handle {
+    background-color: #fff;
+    border-radius: 2px;
+    box-shadow: rgba(0, 0, 0, 0.16) 0px 2px 4px 0px;
+    font-family: verdana, sans-serif;
+    font-size: 12px;
+    font-weight: 500;
+    color: rgba(0, 0, 0, .87);
+    fill: #fff;
+}
+
+.relation-label {
+    font-family: verdana, sans-serif;
+    font-size: 12px;
+    font-weight: 500;
+    color: rgba(0, 0, 0, .87);
+    fill: rgba(0, 0, 0, .87);
 }

--- a/WwwSqlDesigner/wwwroot/styles/material-inspired.css
+++ b/WwwSqlDesigner/wwwroot/styles/material-inspired.css
@@ -724,10 +724,35 @@ label, input, select {
     fill: #fff;
 }
 
-.relation-label {
-    font-family: verdana, sans-serif;
-    font-size: 12px;
-    font-weight: 500;
+.relation-handle-transitioning {
+    transition: x 120ms ease-out, y 120ms ease-out, width 120ms ease-out, height 120ms ease-out;
+}
+
+input.relation-name-input {
+    position: absolute;
+    z-index: 2;
+    appearance: none;
+    -webkit-appearance: none;
+    box-sizing: border-box;
+    border: 0;
+    border-radius: 2px;
+    outline: none;
+    padding: 0;
+    background: transparent;
     color: rgba(0, 0, 0, .87);
-    fill: rgba(0, 0, 0, .87);
+    font: 500 12px verdana, sans-serif;
+    line-height: 24px;
+    text-align: center;
+    cursor: pointer;
+}
+
+input.relation-name-input:focus {
+    border: 0;
+    border-bottom: 0;
+    box-shadow: none;
+    outline: none;
+}
+
+input.relation-name-input:not([readonly]) {
+    cursor: text;
 }

--- a/WwwSqlDesigner/wwwroot/styles/original.css
+++ b/WwwSqlDesigner/wwwroot/styles/original.css
@@ -381,4 +381,21 @@ label, input, select {
 .diagram-legend-timestamp > span.empty {
     opacity: .7;
     font-style: italic;
+.relation-handle {
+    background-color: #fff;
+    border-radius: 3px;
+    box-shadow: 2px 2px 4px #888;
+    font-family: verdana, sans-serif;
+    font-size: 12px;
+    font-weight: bold;
+    color: #000;
+    fill: #fff;
+}
+
+.relation-label {
+    font-family: verdana, sans-serif;
+    font-size: 12px;
+    font-weight: bold;
+    color: #000;
+    fill: #000;
 }

--- a/WwwSqlDesigner/wwwroot/styles/original.css
+++ b/WwwSqlDesigner/wwwroot/styles/original.css
@@ -392,10 +392,35 @@ label, input, select {
     fill: #fff;
 }
 
-.relation-label {
-    font-family: verdana, sans-serif;
-    font-size: 12px;
-    font-weight: bold;
+.relation-handle-transitioning {
+    transition: x 120ms ease-out, y 120ms ease-out, width 120ms ease-out, height 120ms ease-out;
+}
+
+input.relation-name-input {
+    position: absolute;
+    z-index: 2;
+    appearance: none;
+    -webkit-appearance: none;
+    box-sizing: border-box;
+    border: 0;
+    border-radius: 3px;
+    outline: none;
+    padding: 0;
+    background: transparent;
     color: #000;
-    fill: #000;
+    font: bold 12px verdana, sans-serif;
+    line-height: 24px;
+    text-align: center;
+    cursor: pointer;
+}
+
+input.relation-name-input:focus {
+    border: 0;
+    border-bottom: 0;
+    box-shadow: none;
+    outline: none;
+}
+
+input.relation-name-input:not([readonly]) {
+    cursor: text;
 }

--- a/WwwSqlDesigner/wwwroot/styles/original.css
+++ b/WwwSqlDesigner/wwwroot/styles/original.css
@@ -392,7 +392,7 @@ label, input, select {
     fill: #fff;
 }
 
-.relation-handle-transitioning {
+.relation-handle.relation-control-transitioning {
     transition: x 120ms ease-out, y 120ms ease-out, width 120ms ease-out, height 120ms ease-out;
 }
 
@@ -412,6 +412,10 @@ input.relation-name-input {
     line-height: 24px;
     text-align: center;
     cursor: pointer;
+}
+
+input.relation-name-input.relation-control-transitioning {
+    transition: left 120ms ease-out, top 120ms ease-out, width 120ms ease-out, height 120ms ease-out;
 }
 
 input.relation-name-input:focus {

--- a/WwwSqlDesigner/wwwroot/styles/original.css
+++ b/WwwSqlDesigner/wwwroot/styles/original.css
@@ -393,7 +393,7 @@ label, input, select {
 }
 
 .relation-handle.relation-control-transitioning {
-    transition: x 120ms ease-out, y 120ms ease-out, width 120ms ease-out, height 120ms ease-out;
+    transition: left 120ms ease-out, top 120ms ease-out, x 120ms ease-out, y 120ms ease-out, width 120ms ease-out, height 120ms ease-out;
 }
 
 input.relation-name-input {
@@ -427,4 +427,9 @@ input.relation-name-input:focus {
 
 input.relation-name-input:not([readonly]) {
     cursor: text;
+}
+
+input.relation-name-input::placeholder {
+    color: inherit;
+    opacity: 1;
 }


### PR DESCRIPTION
## Summary
- Add optional diagram-only names to foreign-key relationships.
- Provide centered, clickable relationship controls that expand from + to the relationship name.
- Persist names in model XML without changing SQL or Entity Framework exports.

## Validation
- npm test -- relationship-names.spec.mjs (3 passed)
- dotnet build WwwSqlDesigner.sln --no-restore
- dotnet test WwwSqlDesigner.sln --no-restore (22 passed)