### PR TITLE
AB#15374 Add diagram summary legend

### DIFF
--- a/WwwSqlDesigner.Tests/Playwright/tests/diagram-legend.spec.mjs
+++ b/WwwSqlDesigner.Tests/Playwright/tests/diagram-legend.spec.mjs
@@ -1,0 +1,112 @@
+import { test, expect } from "@playwright/test";
+
+test("edits, saves, reloads, and safely renders the diagram summary", async ({ page }) => {
+    await page.goto("/");
+
+    const legend = page.locator(".diagram-legend");
+    await expect(legend).toBeHidden();
+    await page.locator("#maptoggle").click();
+    await expect(legend).toBeVisible();
+    await expect(page.locator("#maptools")).toHaveCSS("position", "fixed");
+    await expect(page.locator("#maptools")).toHaveCSS("width", "190px");
+    await expect(page.locator("#maptools")).toHaveCSS("bottom", "0px");
+    expect(await page.locator("#maptoggle").evaluate((toggle) => {
+        const bounds = toggle.getBoundingClientRect();
+        return Math.round(bounds.bottom) === window.innerHeight;
+    })).toBe(true);
+    await expect(page.locator("#bar")).toHaveCSS("max-height", "22px");
+    await expect(page.locator("#bar")).toHaveCSS("overflow", "hidden");
+    await expect(page.locator("#maptools #minimap")).toBeVisible();
+    await expect(page.locator("#maptools #minimap")).toHaveCSS("width", "190px");
+    await expect(page.locator("#maptools #minimap")).toHaveCSS("height", "190px");
+    expect(await page.locator("#minimap").evaluate((minimap) => {
+        const bounds = minimap.getBoundingClientRect();
+        return minimap.contains(document.elementFromPoint(bounds.left + 4, bounds.top + 4));
+    })).toBe(true);
+    await expect(legend.getByText("Not yet saved", { exact: true })).toHaveCount(2);
+    await expect(legend.getByLabel("Diagram name")).not.toHaveAttribute("placeholder");
+    expect(await legend.locator("input").evaluateAll((inputs) => inputs.map((input) => input.getAttribute("aria-label")))).toEqual([
+        "Diagram name", "Title", "Application name", "Author",
+    ]);
+    await page.locator("#maptoggle").click();
+    await expect(legend).toBeHidden();
+    await page.locator("#maptoggle").click();
+    await expect(legend).toBeVisible();
+
+    const markup = '<img src=x data-xss="legend">';
+    await legend.getByLabel("Diagram name").fill(markup);
+    await legend.getByLabel("Title").fill("Contract Management System");
+    await legend.getByLabel("Author").fill("Jacob Will Smith");
+    await legend.getByLabel("Application name").fill("Contracts");
+
+    await page.locator("#saveload").click();
+    await page.locator("#clientsave").click();
+    const xml = await page.locator("#textarea").inputValue();
+    expect(xml).toContain('<legend name="&lt;img src=x data-xss=&quot;legend&quot;&gt;"');
+    expect(xml).toMatch(/created="[^"]+" modified="[^"]+"/);
+    await page.locator("#clientload").click();
+
+    await expect(legend.getByLabel("Diagram name")).toHaveValue(markup);
+    await expect(legend.getByLabel("Title")).toHaveValue("Contract Management System");
+    expect(await legend.locator("img").count()).toBe(0);
+});
+
+test("does not update summary timestamps for exports or no-op saves", async ({ page }) => {
+    await page.goto("/");
+    await page.locator("#maptoggle").click();
+    await page.locator(".diagram-legend").getByLabel("Title").fill("Export-safe diagram");
+    await page.locator("#saveload").click();
+    await page.locator("#clientsave").click();
+    const firstXml = await page.locator("#textarea").inputValue();
+    const created = firstXml.match(/<legend[^>]* created="([^"]+)"/)[1];
+    const modified = firstXml.match(/<legend[^>]* modified="([^"]+)"/)[1];
+
+    await page.locator("#clientsql").click();
+    await expect(page.locator("#throbber")).toBeHidden();
+    const afterExport = await page.evaluate(() => d.legend.data.modified);
+    expect(afterExport).toBe(modified);
+
+    await page.locator("#clientsave").click();
+    const secondXml = await page.locator("#textarea").inputValue();
+    expect(secondXml.match(/<legend[^>]* created="([^"]+)"/)[1]).toBe(created);
+    expect(secondXml.match(/<legend[^>]* modified="([^"]+)"/)[1]).toBe(modified);
+
+    await page.locator(".diagram-legend").getByLabel("Author").fill("Updated author");
+    await page.locator("#clientsave").click();
+    const changedXml = await page.locator("#textarea").inputValue();
+    expect(changedXml.match(/<legend[^>]* created="([^"]+)"/)[1]).toBe(created);
+    expect(changedXml.match(/<legend[^>]* modified="([^"]+)"/)[1]).not.toBe(modified);
+});
+
+test("adds timestamps when an older model is first saved", async ({ page }) => {
+    await page.goto("/");
+    await page.evaluate(() => {
+        d.fromXML(new DOMParser().parseFromString("<sql />", "text/xml").documentElement);
+    });
+    await page.locator("#saveload").click();
+    await page.locator("#clientsave").click();
+    const xml = await page.locator("#textarea").inputValue();
+    expect(xml).toMatch(/<legend[^>]* created="[^"]+" modified="[^"]+"/);
+});
+
+test("preserves aspect ratio for tall diagrams in the square minimap", async ({ page }) => {
+    await page.goto("/");
+    const map = await page.evaluate(() => {
+        d.width = 3000;
+        d.height = 6000;
+        d.map.sync();
+        return {
+            width: d.map.width,
+            height: d.map.height,
+            mapWidth: d.map.mapWidth,
+            mapHeight: d.map.mapHeight,
+            offsetX: d.map.offsetX,
+            offsetY: d.map.offsetY,
+        };
+    });
+
+    expect(map.mapHeight).toBeCloseTo(map.height);
+    expect(map.mapWidth).toBeCloseTo(map.width / 2);
+    expect(map.offsetX).toBeCloseTo(map.width / 4);
+    expect(map.offsetY).toBeCloseTo(0);
+});

--- a/WwwSqlDesigner/wwwroot/index.html
+++ b/WwwSqlDesigner/wwwroot/index.html
@@ -24,6 +24,8 @@
     <script src="js/key.js"></script>
     <script src="js/rubberband.js"></script>
     <script src="js/map.js"></script>
+    <script src="js/maptools.js"></script>
+    <script src="js/legend.js"></script>
     <script src="js/toggle.js"></script>
     <script src="js/io.js"></script>
     <script src="js/tablemanager.js"></script>
@@ -70,7 +72,13 @@
 
         <div id="rubberband"></div>
 
-        <div id="minimap"></div>
+        <div id="maptools">
+            <div id="minimap"></div>
+            <details id="legendtools">
+                <summary id="maptoggle" aria-label="Diagram details"></summary>
+                <div id="maptoolcontent"></div>
+            </details>
+        </div>
 
         <div id="background"></div>
 

--- a/WwwSqlDesigner/wwwroot/js/io.js
+++ b/WwwSqlDesigner/wwwroot/js/io.js
@@ -153,7 +153,7 @@ SQL.IO.prototype.fromXML = function (xmlDoc) {
 };
 
 SQL.IO.prototype.clientsave = function () {
-    const xml = this.owner.toXML();
+    const xml = this.owner.toXML(true);
     this.dom.ta.value = xml;
 };
 
@@ -188,17 +188,17 @@ SQL.IO.prototype.clientlocalsave = function () {
         return;
     }
 
-    const xml = this.owner.toXML();
+    let key = this.promptName("serversaveprompt");
+    if (!key) {
+        return;
+    }
+
+    const xml = this.owner.toXML(true);
     if (xml.length >= (5 * 1024 * 1024) / 2) {
         /* this is a very big db structure... */
         alert(
             "Warning: your database structure is above 5 megabytes in size, this is above the localStorage single key limit allowed by some browsers, example Mozilla Firefox 10"
         );
-        return;
-    }
-
-    let key = this.promptName("serversaveprompt");
-    if (!key) {
         return;
     }
 
@@ -522,7 +522,7 @@ SQL.IO.prototype.serversave = function (e, keyword) {
         return;
     }
     this._name = name;
-    const xml = this.owner.toXML();
+    const xml = this.owner.toXML(true);
     const bp = this.owner.getOption("xhrpath");
     const url =
         bp +

--- a/WwwSqlDesigner/wwwroot/js/legend.js
+++ b/WwwSqlDesigner/wwwroot/js/legend.js
@@ -1,0 +1,107 @@
+SQL.Legend = function (owner) {
+    this.owner = owner;
+    this.data = {
+        name: "",
+        title: "",
+        author: "",
+        application: "",
+        created: "",
+        modified: "",
+    };
+    this.savedXml = null;
+    this.dom = { inputs: {}, timestamps: {} };
+
+    const container = document.createElement("section");
+    container.className = "diagram-legend";
+    container.setAttribute("aria-label", _("diagramsummary"));
+    this.dom.container = container;
+
+    this.addInput("name", "legendname");
+    this.addInput("title", "legendtitle");
+    this.addInput("application", "legendapplication");
+    this.addInput("author", "legendauthor");
+    this.addTimestamp("created", "legendcreated");
+    this.addTimestamp("modified", "legendmodified");
+    OZ.$("maptoolcontent").appendChild(container);
+    this.redraw();
+};
+
+SQL.Legend.prototype.addInput = function (name, label) {
+    const row = document.createElement("label");
+    row.className = "diagram-legend-row";
+    const caption = document.createElement("span");
+    caption.textContent = _(label);
+    const input = document.createElement("input");
+    input.type = "text";
+    input.setAttribute("aria-label", _(label));
+    input.addEventListener("input", () => {
+        this.data[name] = input.value;
+    });
+    row.appendChild(caption);
+    row.appendChild(input);
+    this.dom.container.appendChild(row);
+    this.dom.inputs[name] = input;
+};
+
+SQL.Legend.prototype.addTimestamp = function (name, label) {
+    const row = document.createElement("div");
+    row.className = "diagram-legend-row diagram-legend-timestamp";
+    const caption = document.createElement("span");
+    caption.textContent = _(label);
+    const value = document.createElement("span");
+    row.appendChild(caption);
+    row.appendChild(value);
+    this.dom.container.appendChild(row);
+    this.dom.timestamps[name] = value;
+};
+
+SQL.Legend.prototype.redraw = function () {
+    for (let name in this.dom.inputs) {
+        this.dom.inputs[name].value = this.data[name];
+    }
+    for (let name in this.dom.timestamps) {
+        const value = this.dom.timestamps[name];
+        value.textContent = this.formatDate(this.data[name]);
+        value.className = this.data[name] ? "" : "empty";
+    }
+};
+
+SQL.Legend.prototype.formatDate = function (value) {
+    if (!value) {
+        return _("legendnotsaved");
+    }
+    const date = new Date(value);
+    return isNaN(date.getTime()) ? _("legendnotsaved") : date.toLocaleString();
+};
+
+SQL.Legend.prototype.toXML = function () {
+    const attrs = [];
+    for (let name in this.data) {
+        attrs.push(name + '="' + SQL.escape(this.data[name]).replace(/"/g, "&quot;") + '"');
+    }
+    return "<legend " + attrs.join(" ") + " />\n";
+};
+
+SQL.Legend.prototype.fromXML = function (node) {
+    for (let name in this.data) {
+        this.data[name] = node ? (node.getAttribute(name) || "") : "";
+    }
+    this.redraw();
+};
+
+SQL.Legend.prototype.prepareForSave = function () {
+    const currentXml = this.owner.toXML();
+    if (this.data.created && this.savedXml === currentXml) {
+        return;
+    }
+    const now = new Date().toISOString();
+    if (!this.data.created) {
+        this.data.created = now;
+    }
+    this.data.modified = now;
+    this.redraw();
+};
+
+SQL.Legend.prototype.rememberSaved = function (xml) {
+    this.savedXml = xml || this.owner.toXML();
+};

--- a/WwwSqlDesigner/wwwroot/js/map.js
+++ b/WwwSqlDesigner/wwwroot/js/map.js
@@ -28,8 +28,8 @@ SQL.Map.prototype.down = function (e) {
     this.dom.container.style.cursor = "move";
     const pos = OZ.DOM.pos(this.dom.container);
 
-    this.x = Math.round(pos[0] + this.l + this.w / 2);
-    this.y = Math.round(pos[1] + this.t + this.h / 2);
+    this.x = Math.round(pos[0] + this.offsetX + this.l + this.w / 2);
+    this.y = Math.round(pos[1] + this.offsetY + this.t + this.h / 2);
     this.move(e);
 
     let eventMove = "";
@@ -72,11 +72,11 @@ SQL.Map.prototype.move = function (e) {
     if (this.t + dy < 0) {
         dy = -this.t;
     }
-    if (this.l + this.w + 4 + dx > this.width) {
-        dx = this.width - 4 - this.l - this.w;
+    if (this.l + this.w + 4 + dx > this.mapWidth) {
+        dx = this.mapWidth - 4 - this.l - this.w;
     }
-    if (this.t + this.h + 4 + dy > this.height) {
-        dy = this.height - 4 - this.t - this.h;
+    if (this.t + this.h + 4 + dy > this.mapHeight) {
+        dy = this.mapHeight - 4 - this.t - this.h;
     }
 
     this.x += dx;
@@ -85,10 +85,8 @@ SQL.Map.prototype.move = function (e) {
     this.l += dx;
     this.t += dy;
 
-    let coefX = this.width / this.owner.width;
-    let coefY = this.height / this.owner.height;
-    let left = this.l / coefX;
-    let top = this.t / coefY;
+    let left = this.l / this.scale;
+    let top = this.t / this.scale;
 
     document.documentElement.scrollLeft = Math.round(left);
     document.documentElement.scrollTop = Math.round(top);
@@ -106,15 +104,20 @@ SQL.Map.prototype.up = function (e) {
 
 SQL.Map.prototype.sync = function () {
     /* when window changes, adjust map */
+    this.width = this.dom.container.offsetWidth - 2;
+    this.height = this.dom.container.offsetHeight - 2;
     const dims = OZ.DOM.win();
     const scroll = OZ.DOM.scroll();
-    const scaleX = this.width / this.owner.width;
-    const scaleY = this.height / this.owner.height;
+    this.scale = Math.min(this.width / this.owner.width, this.height / this.owner.height);
+    this.mapWidth = this.owner.width * this.scale;
+    this.mapHeight = this.owner.height * this.scale;
+    this.offsetX = (this.width - this.mapWidth) / 2;
+    this.offsetY = (this.height - this.mapHeight) / 2;
 
-    const w = dims[0] * scaleX - 4 - 0;
-    const h = dims[1] * scaleY - 4 - 0;
-    const x = scroll[0] * scaleX;
-    const y = scroll[1] * scaleY;
+    const w = dims[0] * this.scale - 4;
+    const h = dims[1] * this.scale - 4;
+    const x = scroll[0] * this.scale;
+    const y = scroll[1] * this.scale;
 
     this.w = Math.round(w);
     this.h = Math.round(h);
@@ -127,6 +130,6 @@ SQL.Map.prototype.sync = function () {
 SQL.Map.prototype.redraw = function () {
     this.dom.port.style.width = this.w + "px";
     this.dom.port.style.height = this.h + "px";
-    this.dom.port.style.left = this.l + "px";
-    this.dom.port.style.top = this.t + "px";
+    this.dom.port.style.left = this.offsetX + this.l + "px";
+    this.dom.port.style.top = this.offsetY + this.t + "px";
 };

--- a/WwwSqlDesigner/wwwroot/js/maptools.js
+++ b/WwwSqlDesigner/wwwroot/js/maptools.js
@@ -1,0 +1,79 @@
+SQL.MapTools = function (owner) {
+    this.owner = owner;
+    this.dom = {
+        container: OZ.$("maptools"),
+        details: OZ.$("legendtools"),
+        content: OZ.$("maptoolcontent"),
+        toggle: OZ.$("maptoggle"),
+    };
+    this.animating = false;
+    OZ.Event.add(this.dom.toggle, "click", this.click.bind(this));
+};
+
+SQL.MapTools.prototype.sync = function () {
+    if (this.dom.details.open) {
+        this.dom.container.style.height = this.getExpandedHeight() + "px";
+    } else {
+        this.dom.container.style.height = this.getCollapsedHeight() + "px";
+    }
+};
+
+SQL.MapTools.prototype.click = function (e) {
+    e.preventDefault();
+    if (this.animating) {
+        return;
+    }
+    if (!this.dom.details.open) {
+        const start = this.getCollapsedHeight();
+        this.owner.toolbarToggle._switch(false);
+        this.dom.details.open = true;
+        this.owner.map.sync();
+        this.animate(start, this.getExpandedHeight());
+        return;
+    }
+
+    this.close();
+};
+
+SQL.MapTools.prototype.close = function () {
+    if (!this.dom.details.open || this.animating) {
+        return;
+    }
+    this.animate(this.dom.container.offsetHeight, this.getCollapsedHeight(), () => {
+        this.dom.details.open = false;
+        this.dom.container.style.height = this.getCollapsedHeight() + "px";
+    });
+};
+
+SQL.MapTools.prototype.getExpandedHeight = function () {
+    return this.dom.content.offsetHeight + this.getCollapsedHeight();
+};
+
+SQL.MapTools.prototype.getCollapsedHeight = function () {
+    return this.owner.map.dom.container.offsetHeight + this.dom.toggle.offsetHeight;
+};
+
+SQL.MapTools.prototype.animate = function (start, end, finished) {
+    if (!this.dom.container.animate) {
+        this.dom.container.style.height = end + "px";
+        if (finished) {
+            finished();
+        }
+        return;
+    }
+    this.animating = true;
+    this.dom.container.style.height = start + "px";
+    this.dom.container.style.overflow = "hidden";
+    const animation = this.dom.container.animate([
+        { height: start + "px" },
+        { height: end + "px" },
+    ], { duration: 180, easing: "ease-in-out" });
+    animation.onfinish = () => {
+        this.dom.container.style.height = end + "px";
+        this.dom.container.style.overflow = "";
+        this.animating = false;
+        if (finished) {
+            finished();
+        }
+    };
+};

--- a/WwwSqlDesigner/wwwroot/js/rubberband.js
+++ b/WwwSqlDesigner/wwwroot/js/rubberband.js
@@ -9,6 +9,9 @@ SQL.Rubberband = function (owner) {
 SQL.Rubberband.prototype = Object.create(SQL.Visual.prototype);
 
 SQL.Rubberband.prototype.down = function (e) {
+    if (e.target && e.target.closest && e.target.closest(".diagram-legend")) {
+        return;
+    }
     OZ.Event.prevent(e);
     const scroll = OZ.DOM.scroll();
     this.x = this.x0 = e.clientX + scroll[0];

--- a/WwwSqlDesigner/wwwroot/js/toggle.js
+++ b/WwwSqlDesigner/wwwroot/js/toggle.js
@@ -20,6 +20,10 @@ SQL.Toggle.prototype._switch = function (state) {
     this._state = state;
     if (this._state) {
         OZ.$("bar").style.maxHeight = "";
+        OZ.$("bar").style.overflow = "";
+        if (SQL.Designer.mapTools) {
+            SQL.Designer.mapTools.close();
+        }
     } else {
         OZ.$("bar").style.overflow = "hidden";
         OZ.$("bar").style.maxHeight = this._elm.offsetHeight + "px";

--- a/WwwSqlDesigner/wwwroot/js/wwwsqldesigner.js
+++ b/WwwSqlDesigner/wwwroot/js/wwwsqldesigner.js
@@ -7,7 +7,7 @@ SQL.Designer = function () {
     this.title = document.title;
 
     SQL.Visual.apply(this);
-    new SQL.Toggle(OZ.$("toggle"));
+    this.toolbarToggle = new SQL.Toggle(OZ.$("toggle"));
 
     this.dom.container = OZ.$("area");
     this.minSize = [
@@ -116,7 +116,10 @@ SQL.Designer.prototype.applyStyle = function () {
 
 SQL.Designer.prototype.init2 = function () {
     /* secondary init, after locale & datatypes were retrieved */
+    this.mapTools = new SQL.MapTools(this);
+    this.legend = new SQL.Legend(this);
     this.map = new SQL.Map(this);
+    this.mapTools.sync();
     this.rubberband = new SQL.Rubberband(this);
     this.tableManager = new SQL.TableManager(this);
     this.rowManager = new SQL.RowManager(this);
@@ -332,10 +335,14 @@ SQL.Designer.prototype.findNamedTable = function (name) {
     }
 };
 
-SQL.Designer.prototype.toXML = function () {
+SQL.Designer.prototype.toXML = function (recordSave) {
+    if (recordSave) {
+        this.legend.prepareForSave();
+    }
     let xml = '<?xml version="1.0" encoding="utf-8" ?>\n';
     xml += "<!-- SQL XML created by WWW SQL Designer, https://github.com/ondras/wwwsqldesigner/ -->\n";
     xml += "<sql>\n";
+    xml += this.legend.toXML();
 
     /* serialize datatypes */
     if (window.XMLSerializer) {
@@ -351,11 +358,16 @@ SQL.Designer.prototype.toXML = function () {
         xml += table.toXML();
     }
     xml += "</sql>\n";
+    if (recordSave) {
+        this.legend.rememberSaved(xml);
+    }
     return xml;
 };
 
 SQL.Designer.prototype.fromXML = function (node) {
     this.clearTables();
+    const legends = node.getElementsByTagName("legend");
+    this.legend.fromXML(legends.length ? legends[0] : null);
     const types = node.getElementsByTagName("datatypes");
     if (types.length) {
         window.DATATYPES = types[0];
@@ -402,6 +414,7 @@ SQL.Designer.prototype.fromXML = function (node) {
     }
 
     this.sync();
+    this.legend.rememberSaved(this.toXML());
 };
 
 SQL.Designer.prototype.setTitle = function (t) {

--- a/WwwSqlDesigner/wwwroot/locale/en.xml
+++ b/WwwSqlDesigner/wwwroot/locale/en.xml
@@ -105,5 +105,13 @@
     <!-- misc -->
     <string name="xmlerror">XML error</string>
     <string name="docs">Documentation</string>
+    <string name="diagramsummary">Diagram summary</string>
+    <string name="legendname">Diagram name</string>
+    <string name="legendtitle">Title</string>
+    <string name="legendauthor">Author</string>
+    <string name="legendapplication">Application name</string>
+    <string name="legendcreated">Created</string>
+    <string name="legendmodified">Last modified</string>
+    <string name="legendnotsaved">Not yet saved</string>
 
 </locale>

--- a/WwwSqlDesigner/wwwroot/styles/material-inspired.css
+++ b/WwwSqlDesigner/wwwroot/styles/material-inspired.css
@@ -191,7 +191,8 @@ label, input, select {
     box-shadow: rgba(0, 0, 0, 0.16) 0px 3px 6px 0px, rgba(0, 0, 0, 0.23) 0px 3px 6px 0px;
     box-sizing: border-box;
     max-height: 600px;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 
 #bar input {

--- a/WwwSqlDesigner/wwwroot/styles/material-inspired.css
+++ b/WwwSqlDesigner/wwwroot/styles/material-inspired.css
@@ -191,6 +191,7 @@ label, input, select {
     box-shadow: rgba(0, 0, 0, 0.16) 0px 3px 6px 0px, rgba(0, 0, 0, 0.23) 0px 3px 6px 0px;
     box-sizing: border-box;
     max-height: 600px;
+    overflow: hidden;
 }
 
 #bar input {
@@ -590,4 +591,125 @@ label, input, select {
     font-size: small;
     border: 1px solid rgba(0, 0, 0, .26);
     padding: 0px;
+}
+
+#maptools {
+    position: fixed;
+    right: 4px;
+    bottom: 0;
+    z-index: 1000;
+    width: 190px;
+    height: 212px;
+    overflow: hidden;
+    background: #fff;
+    border-radius: 2px;
+    box-shadow: rgba(0, 0, 0, 0.16) 0 3px 6px, rgba(0, 0, 0, 0.23) 0 3px 6px;
+}
+
+#legendtools {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+#maptoggle {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    z-index: 1;
+    pointer-events: auto;
+    list-style: none;
+    width: 100%;
+    height: 22px;
+    cursor: pointer;
+    opacity: .7;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
+#maptoggle:hover {
+    background-color: #de2665;
+}
+
+#maptoggle::-webkit-details-marker { display: none; }
+#maptoggle { background-image: url(../images/up_2_black.png); }
+#maptoggle:hover { background-image: url(../images/up_2_white.png); }
+#legendtools[open] #maptoggle { background-image: url(../images/down_2_black.png); }
+#legendtools[open] #maptoggle:hover { background-image: url(../images/down_2_white.png); }
+
+#maptools #minimap {
+    position: absolute;
+    right: 0;
+    bottom: 22px;
+    width: 100%;
+    height: 190px;
+    margin: 0;
+    border: 1px solid rgba(0, 0, 0, .38);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, .55), 0 1px 3px rgba(0, 0, 0, .18);
+    box-sizing: border-box;
+}
+
+#maptoolcontent {
+    position: absolute;
+    right: 0;
+    bottom: 212px;
+    left: 0;
+    box-sizing: border-box;
+    pointer-events: auto;
+}
+
+.diagram-legend {
+    width: 100%;
+    margin: 0 auto;
+    padding: 8px;
+    box-sizing: border-box;
+    background: #fff;
+    border-radius: 2px;
+    color: rgba(0, 0, 0, .87);
+    user-select: text;
+}
+
+.diagram-legend-row {
+    display: block;
+    margin: 4px 0;
+}
+
+.diagram-legend-row > span:first-child {
+    display: block;
+    opacity: .7;
+    margin-bottom: 1px;
+}
+
+.diagram-legend input[type=text] {
+    display: block;
+    min-width: 0;
+    width: 100%;
+    height: 22px;
+    padding: 0;
+    border: 0;
+    border-bottom: 1px solid rgba(0, 0, 0, .26);
+    font-family: inherit;
+    font: inherit;
+    background: transparent;
+    box-sizing: border-box;
+}
+
+.diagram-legend input[type=text]:focus {
+    border-bottom-color: #2196F3;
+    outline: 0;
+}
+
+.diagram-legend-timestamp > span:last-child {
+    display: block;
+    min-height: 22px;
+    padding: 2px 0;
+    box-sizing: border-box;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.diagram-legend-timestamp > span.empty {
+    opacity: .7;
+    font-style: italic;
 }

--- a/WwwSqlDesigner/wwwroot/styles/original.css
+++ b/WwwSqlDesigner/wwwroot/styles/original.css
@@ -33,7 +33,8 @@ body {
     right: 0px;
     width: 150px;
     padding: 0px 5px 5px;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
     -moz-box-shadow: -4px 4px 8px #888;
     /* FF 3.5+ */
     -webkit-box-shadow: -4px 4px 8px #888;

--- a/WwwSqlDesigner/wwwroot/styles/original.css
+++ b/WwwSqlDesigner/wwwroot/styles/original.css
@@ -33,6 +33,7 @@ body {
     right: 0px;
     width: 150px;
     padding: 0px 5px 5px;
+    overflow: hidden;
     -moz-box-shadow: -4px 4px 8px #888;
     /* FF 3.5+ */
     -webkit-box-shadow: -4px 4px 8px #888;
@@ -279,4 +280,104 @@ label, input, select {
     background: #888;
     opacity: 0.5;
     visibility: hidden;
+}
+
+#maptools {
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    z-index: 1000;
+    width: 150px;
+    height: 165px;
+    overflow: hidden;
+    background: #fff;
+    border: 1px solid #000;
+}
+
+#legendtools {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+#maptoggle {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    z-index: 1;
+    pointer-events: auto;
+    list-style: none;
+    width: 100%;
+    height: 15px;
+    cursor: pointer;
+    background-position: 50% 5px;
+    background-repeat: no-repeat;
+}
+
+#maptoggle:hover { background-color: #bbb; }
+#maptoggle::-webkit-details-marker { display: none; }
+#maptoggle { background-image: url(../images/up.gif); }
+#legendtools[open] #maptoggle { background-image: url(../images/down.gif); }
+
+#maptools #minimap {
+    position: absolute;
+    right: 0;
+    bottom: 15px;
+    width: 100%;
+    height: 150px;
+    margin: 0;
+    box-sizing: border-box;
+}
+
+#maptoolcontent {
+    position: absolute;
+    right: 0;
+    bottom: 165px;
+    left: 0;
+    box-sizing: border-box;
+    pointer-events: auto;
+}
+
+.diagram-legend {
+    width: 100%;
+    margin: 0 auto;
+    padding: 8px;
+    box-sizing: border-box;
+    background: #fff;
+    border: 1px solid #000;
+    color: #000;
+    user-select: text;
+}
+
+.diagram-legend-row {
+    display: block;
+    margin: 4px 0;
+    font-size: 11px;
+}
+
+.diagram-legend-row > span:first-child,
+.diagram-legend-timestamp > span:last-child {
+    display: block;
+}
+
+.diagram-legend-row > span:first-child {
+    margin-bottom: 1px;
+}
+
+.diagram-legend-timestamp > span:last-child {
+    min-height: 22px;
+    padding: 2px 0;
+    box-sizing: border-box;
+}
+
+.diagram-legend input[type=text] {
+    min-width: 0;
+    width: 100%;
+    box-sizing: border-box;
+    font: inherit;
+}
+
+.diagram-legend-timestamp > span.empty {
+    opacity: .7;
+    font-style: italic;
 }


### PR DESCRIPTION
## Summary
- Adds persisted, directly editable diagram summary metadata.
- Adds an always-visible square minimap and collapsible diagram details panel.
- Keeps generated SQL and EF output unchanged.

## Validation
- Focused Playwright: 4 passed.