### PR TITLE
AB#33930 Add portable schema metadata

### DIFF
--- a/WwwSqlDesigner.Tests/Playwright/tests/portable-schema.spec.mjs
+++ b/WwwSqlDesigner.Tests/Playwright/tests/portable-schema.spec.mjs
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+
+async function load(page, xml) {
+    await page.evaluate((value) => d.fromXML(new DOMParser().parseFromString(value, "text/xml").documentElement), xml);
+}
+
+test("round-trips every canonical portable token and facet", async ({ page }) => {
+    await page.goto("/");
+    const tokens = ["integer", "decimal(10,2)", "float", "string(100)", "text", "boolean", "date", "time", "datetime", "datetime-with-time-zone", "binary(16)", "uuid", "json", "xml"];
+    const rows = tokens.map((token, index) => `<row name="C${index}" null="1"><datatype>${token}</datatype><default>value</default><comment>note</comment></row>`).join("");
+    await load(page, `<sql format="portable-v1"><datatypes db="portable" /><table name="All">${rows}</table></sql>`);
+    const saved = await page.evaluate(() => d.toXML());
+    expect(saved).toContain('<sql format="portable-v1">');
+    expect(saved).toContain('<datatypes db="portable">');
+    for (const token of tokens) { expect(saved).toContain(`<datatype>${token}</datatype>`); }
+    await load(page, saved);
+    expect(await page.evaluate(() => d.toXML())).toContain("<datatype>datetime-with-time-zone</datatype>");
+});
+
+test("blocks unsupported input until a portable replacement is selected", async ({ page }) => {
+    await page.goto("/");
+    await load(page, `<sql format="portable-v1"><datatypes db="portable" /><table name="Existing"><row name="Id" null="0"><datatype>integer</datatype></row></table></sql>`);
+    await page.evaluate(() => { window.prompt = () => null; });
+    await load(page, `<sql><datatypes db="mssql" /><table name="Location"><row name="Shape" null="1"><datatype>geography</datatype></row></table></sql>`);
+    expect(await page.locator(".table").count()).toBe(1);
+    await page.evaluate(() => { window.prompt = () => "json"; });
+    await load(page, `<sql><datatypes db="mssql" /><table name="Location"><row name="Shape" null="1"><datatype>geography</datatype></row></table></sql>`);
+    expect(await page.evaluate(() => d.toXML())).toContain("<datatype>json</datatype>");
+});

--- a/WwwSqlDesigner.Tests/Playwright/tests/portable-schema.spec.mjs
+++ b/WwwSqlDesigner.Tests/Playwright/tests/portable-schema.spec.mjs
@@ -27,3 +27,23 @@ test("blocks unsupported input until a portable replacement is selected", async 
     await load(page, `<sql><datatypes db="mssql" /><table name="Location"><row name="Shape" null="1"><datatype>geography</datatype></row></table></sql>`);
     expect(await page.evaluate(() => d.toXML())).toContain("<datatype>json</datatype>");
 });
+test("serializes portable defaults with type-aware quoting", async ({ page }) => {
+    await page.goto("/");
+    await load(page, `<sql format="portable-v1"><datatypes db="portable" /><table name="Defaults"><row name="Text" null="0"><datatype>string(20)</datatype><default>hello</default></row><row name="Amount" null="0"><datatype>decimal(10,2)</datatype><default>12.50</default></row><row name="Empty" null="1"><datatype>string(20)</datatype><default>NULL</default></row><row name="Created" null="0"><datatype>datetime</datatype><default>CURRENT_TIMESTAMP</default></row></table></sql>`);
+    const saved = await page.evaluate(() => d.toXML());
+    expect(saved).toContain("<default>'hello'</default>");
+    expect(saved).toContain("<default>12.50</default>");
+    expect(saved).toContain("<default>'NULL'</default>");
+    expect(saved).toContain("<default>CURRENT_TIMESTAMP</default>");
+    await load(page, saved);
+    expect(await page.evaluate(() => d.toXML())).toBe(saved);
+});
+
+test("maps each unsupported column independently", async ({ page }) => {
+    await page.goto("/");
+    await page.evaluate(() => { const choices = ["uuid", "json"]; window.prompt = () => choices.shift(); });
+    await load(page, `<sql><datatypes db="mssql" /><table name="Legacy"><row name="Key" null="0"><datatype>geography</datatype></row><row name="Document" null="1"><datatype>hierarchyid</datatype></row></table></sql>`);
+    const saved = await page.evaluate(() => d.toXML());
+    expect(saved).toContain("<datatype>uuid</datatype>");
+    expect(saved).toContain("<datatype>json</datatype>");
+});

--- a/WwwSqlDesigner.Tests/Playwright/tests/portable-schema.spec.mjs
+++ b/WwwSqlDesigner.Tests/Playwright/tests/portable-schema.spec.mjs
@@ -33,7 +33,7 @@ test("serializes portable defaults with type-aware quoting", async ({ page }) =>
     const saved = await page.evaluate(() => d.toXML());
     expect(saved).toContain("<default>'hello'</default>");
     expect(saved).toContain("<default>12.50</default>");
-    expect(saved).toContain("<default>'NULL'</default>");
+    expect(saved).toContain("<default>NULL</default>");
     expect(saved).toContain("<default>CURRENT_TIMESTAMP</default>");
     await load(page, saved);
     expect(await page.evaluate(() => d.toXML())).toBe(saved);

--- a/WwwSqlDesigner/wwwroot/index.html
+++ b/WwwSqlDesigner/wwwroot/index.html
@@ -18,6 +18,7 @@
     <script src="js/config.js"></script>
     <script src="js/globals.js"></script>
     <script src="js/visual.js"></script>
+    <script src="js/portabletypes.js"></script>
     <script src="js/row.js"></script>
     <script src="js/table.js"></script>
     <script src="js/relation.js"></script>

--- a/WwwSqlDesigner/wwwroot/js/io.js
+++ b/WwwSqlDesigner/wwwroot/js/io.js
@@ -147,7 +147,7 @@ SQL.IO.prototype.fromXML = function (xmlDoc) {
         alert(_("xmlerror") + ": Null document");
         return false;
     }
-    this.owner.fromXML(xmlDoc.documentElement);
+    if (!this.owner.fromXML(xmlDoc.documentElement)) { return false; }
     this.owner.window.close();
     return true;
 };

--- a/WwwSqlDesigner/wwwroot/js/portabletypes.js
+++ b/WwwSqlDesigner/wwwroot/js/portabletypes.js
@@ -12,7 +12,7 @@ SQL.PortableTypes = {
     },
     split: function (value) { const match = (value || "").trim().match(/^([^()]+?)(?:\((.*)\))?$/); return { name: match ? match[1].trim() : "", facets: match && match[2] ? match[2].trim() : "" }; },
     source: function (dialect, value) { const parsed = this.split(value); const kind = (this.sourceAdapters[(dialect || "").toLowerCase()] || {})[parsed.name.toLowerCase().replace(/\s+/g, " ")]; return kind ? { kind: kind, facets: parsed.facets } : null; },
-    canonical: function (value) { const parsed = this.split(value); return this.tokens.indexOf(parsed.name) !== -1 ? { kind: parsed.name, facets: parsed.facets } : null; },
+    canonical: function (value) { const parsed = this.split(value); const kind = parsed.name.toLowerCase(); return this.tokens.indexOf(kind) !== -1 ? { kind: kind, facets: parsed.facets } : null; },
     formatToken: function (type) { return type.kind + (type.facets ? "(" + type.facets + ")" : ""); },
     map: function (type, target) {
         const dialect = (target || "").toLowerCase(); const result = { type: "", diagnostics: [], safe: true }; result.type = (this.targetAdapters[dialect] || {})[type.kind];

--- a/WwwSqlDesigner/wwwroot/js/portabletypes.js
+++ b/WwwSqlDesigner/wwwroot/js/portabletypes.js
@@ -7,7 +7,7 @@ SQL.PortableTypes = {
     registry: function () {
         const groups = [["Numeric", "integer decimal float"], ["Text", "string text json xml"], ["Date and Time", "date time datetime datetime-with-time-zone"], ["Other", "boolean binary uuid"]];
         let xml = '<datatypes db="portable">';
-        groups.forEach(function (group) { xml += '<group label="' + group[0] + '" color="#eeeeaa">'; group[1].split(" ").forEach(function (token) { xml += '<type label="' + token + '" length="' + (/^(decimal|string|binary)$/.test(token) ? "1" : "0") + '" sql="' + token + '" quote="" />'; }); xml += "</group>"; });
+        groups.forEach(function (group) { xml += '<group label="' + group[0] + '" color="#eeeeaa">'; group[1].split(" ").forEach(function (token) { xml += '<type label="' + token + '" length="' + (/^(decimal|string|binary)$/.test(token) ? "1" : "0") + '" sql="' + token + '" quote="' + (/^(string|text|json|xml|binary)$/.test(token) ? "&apos;" : "") + '" />'; }); xml += "</group>"; });
         return new DOMParser().parseFromString(xml + "</datatypes>", "text/xml").documentElement;
     },
     split: function (value) { const match = (value || "").trim().match(/^([^()]+?)(?:\((.*)\))?$/); return { name: match ? match[1].trim() : "", facets: match && match[2] ? match[2].trim() : "" }; },

--- a/WwwSqlDesigner/wwwroot/js/portabletypes.js
+++ b/WwwSqlDesigner/wwwroot/js/portabletypes.js
@@ -1,0 +1,25 @@
+/* Canonical, persisted column types. Dialect adapters are import/export only. */
+SQL.PortableTypes = {
+    format: "portable-v1",
+    tokens: ["integer", "decimal", "float", "string", "text", "boolean", "date", "time", "datetime", "datetime-with-time-zone", "binary", "uuid", "json", "xml"],
+    sourceAdapters: {},
+    targetAdapters: {},
+    registry: function () {
+        const groups = [["Numeric", "integer decimal float"], ["Text", "string text json xml"], ["Date and Time", "date time datetime datetime-with-time-zone"], ["Other", "boolean binary uuid"]];
+        let xml = '<datatypes db="portable">';
+        groups.forEach(function (group) { xml += '<group label="' + group[0] + '" color="#eeeeaa">'; group[1].split(" ").forEach(function (token) { xml += '<type label="' + token + '" length="' + (/^(decimal|string|binary)$/.test(token) ? "1" : "0") + '" sql="' + token + '" quote="" />'; }); xml += "</group>"; });
+        return new DOMParser().parseFromString(xml + "</datatypes>", "text/xml").documentElement;
+    },
+    split: function (value) { const match = (value || "").trim().match(/^([^()]+?)(?:\((.*)\))?$/); return { name: match ? match[1].trim() : "", facets: match && match[2] ? match[2].trim() : "" }; },
+    source: function (dialect, value) { const parsed = this.split(value); const kind = (this.sourceAdapters[(dialect || "").toLowerCase()] || {})[parsed.name.toLowerCase().replace(/\s+/g, " ")]; return kind ? { kind: kind, facets: parsed.facets } : null; },
+    canonical: function (value) { const parsed = this.split(value); return this.tokens.indexOf(parsed.name) !== -1 ? { kind: parsed.name, facets: parsed.facets } : null; },
+    formatToken: function (type) { return type.kind + (type.facets ? "(" + type.facets + ")" : ""); },
+    map: function (type, target) {
+        const dialect = (target || "").toLowerCase(); const result = { type: "", diagnostics: [], safe: true }; result.type = (this.targetAdapters[dialect] || {})[type.kind];
+        if (!result.type) { result.diagnostics.push(this.formatToken(type) + " cannot be represented by " + dialect + "."); result.safe = false; return result; }
+        if (type.facets && /^(decimal|string|binary)$/.test(type.kind) && !/\(/.test(result.type)) { result.type += "(" + type.facets + ")"; }
+        if (type.kind === "decimal" && type.facets && ["sqlite", "vfp9"].indexOf(dialect) !== -1) { result.diagnostics.push("Precision and scale are not enforced by " + dialect + "."); }
+        if (type.kind === "datetime-with-time-zone" && ["mssql", "postgresql", "oracle", "sqlalchemy", "ef"].indexOf(dialect) === -1) { result.diagnostics.push("Time-zone semantics are not preserved by " + dialect + "."); }
+        return result;
+    }
+};

--- a/WwwSqlDesigner/wwwroot/js/row.js
+++ b/WwwSqlDesigner/wwwroot/js/row.js
@@ -382,104 +382,38 @@ SQL.Row.prototype.destroy = function () {
 };
 
 SQL.Row.prototype.toXML = function () {
-    let xml = "";
-
-    let t = this.getTitle().replace(/"/g, "&quot;");
-    const nn = this.data.nll ? "1" : "0";
-    const ai = this.data.ai ? "1" : "0";
-    xml +=
-        '<row name="' + t + '" null="' + nn + '" autoincrement="' + ai + '">\n';
-
-    const elm = this.getDataType();
-    t = elm.getAttribute("sql");
-    if (this.data.size.length) {
-        t += "(" + this.data.size + ")";
-    }
-    xml += "<datatype>" + t + "</datatype>\n";
-
-    if (this.data.def || this.data.def === null) {
-        const q = elm.getAttribute("quote");
-        let d = this.data.def;
-        if (d === null) {
-            d = "NULL";
-        } else if (d != "CURRENT_TIMESTAMP") {
-            d = q + d + q;
-        }
-        xml += "<default>" + SQL.escape(d) + "</default>";
-    }
-
+    let xml = '';
+    const name = this.getTitle().replace(/"/g, "&quot;");
+    xml += '<row name="' + name + '" null="' + (this.data.nll ? "1" : "0") + '" autoincrement="' + (this.data.ai ? "1" : "0") + '">\n';
+    const type = this.getDataType().getAttribute("sql");
+    xml += "<datatype>" + type + (this.data.size ? "(" + this.data.size + ")" : "") + "</datatype>\n";
+    if (this.data.def || this.data.def === null) { xml += "<default>" + SQL.escape(this.data.def === null ? "NULL" : this.data.def) + "</default>"; }
     for (let relation of this.relations) {
-        if (relation.row2 != this) {
-            continue;
-        }
-        xml +=
-            '<relation table="' +
-            relation.row1.owner.getTitle() +
-            '" row="' +
-            relation.row1.getTitle() +
-            (relation.name
-                ? '" name="' + SQL.escape(relation.name).replace(/"/g, "&quot;")
-                : "") +
-            '" />\n';
+        if (relation.row2 !== this) { continue; }
+        xml += '<relation table="' + relation.row1.owner.getTitle() + '" row="' + relation.row1.getTitle() + (relation.name ? '" name="' + SQL.escape(relation.name).replace(/"/g, "&quot;") : "") + '" />\n';
     }
-
-    if (this.data.comment) {
-        xml += "<comment>" + SQL.escape(this.data.comment) + "</comment>\n";
-    }
-
-    xml += "</row>\n";
-    return xml;
+    if (this.data.comment) { xml += "<comment>" + SQL.escape(this.data.comment) + "</comment>\n"; }
+    return xml + "</row>\n";
 };
 
 SQL.Row.prototype.fromXML = function (node) {
-    const name = node.getAttribute("name");
-
-    const obj = { type: 0, size: "" };
-    obj.nll = node.getAttribute("null") == "1";
-    obj.ai = node.getAttribute("autoincrement") == "1";
-
-    const cs = node.getElementsByTagName("comment");
-    if (cs.length && cs[0].firstChild) {
-        obj.comment = cs[0].firstChild.nodeValue;
-    }
-
-    let d = node.getElementsByTagName("datatype");
-    if (d.length && d[0].firstChild) {
-        const s = d[0].firstChild.nodeValue;
-        const r = s.match(/^([^\(]+)(\((.*)\))?.*$/);
-        const type = r[1];
-        if (r[3]) {
-            obj.size = r[3];
-        }
-        const types = window.DATATYPES.getElementsByTagName("type");
-        for (let i = 0; i < types.length; i++) {
-            const sql = types[i].getAttribute("sql");
-            const re = types[i].getAttribute("re");
-            if (sql == type || (re && new RegExp(re).exec(type))) {
-                obj.type = i;
-            }
+    const obj = { type: 0, size: "", nll: node.getAttribute("null") === "1", ai: node.getAttribute("autoincrement") === "1" };
+    const comment = node.getElementsByTagName("comment")[0];
+    if (comment && comment.firstChild) { obj.comment = comment.firstChild.nodeValue; }
+    const datatype = node.getElementsByTagName("datatype")[0];
+    if (datatype) {
+        const portable = SQL.PortableTypes.canonical(datatype.textContent);
+        if (portable) {
+            obj.size = portable.facets;
+            const types = window.DATATYPES.getElementsByTagName("type");
+            for (let i = 0; i < types.length; i++) { if (types[i].getAttribute("sql") === portable.kind) { obj.type = i; break; } }
         }
     }
-
-    const elm = DATATYPES.getElementsByTagName("type")[obj.type];
-    d = node.getElementsByTagName("default");
-    if (d.length && d[0].firstChild) {
-        const def = d[0].firstChild.nodeValue;
-        obj.def = def;
-        const q = elm.getAttribute("quote");
-        if (q) {
-            const re = new RegExp("^" + q + "(.*)" + q + "$");
-            const r = def.match(re);
-            if (r) {
-                obj.def = r[1];
-            }
-        }
-    }
-
+    const defaultValue = node.getElementsByTagName("default")[0];
+    if (defaultValue && defaultValue.firstChild) { obj.def = defaultValue.firstChild.nodeValue; }
     this.update(obj);
-    this.setTitle(name);
+    this.setTitle(node.getAttribute("name"));
 };
-
 SQL.Row.prototype.isPrimary = function () {
     for (let key of this.keys) {
         if (key.getType() == "PRIMARY") {

--- a/WwwSqlDesigner/wwwroot/js/row.js
+++ b/WwwSqlDesigner/wwwroot/js/row.js
@@ -385,9 +385,15 @@ SQL.Row.prototype.toXML = function () {
     let xml = '';
     const name = this.getTitle().replace(/"/g, "&quot;");
     xml += '<row name="' + name + '" null="' + (this.data.nll ? "1" : "0") + '" autoincrement="' + (this.data.ai ? "1" : "0") + '">\n';
-    const type = this.getDataType().getAttribute("sql");
+    const elm = this.getDataType();
+    const type = elm.getAttribute("sql");
     xml += "<datatype>" + type + (this.data.size ? "(" + this.data.size + ")" : "") + "</datatype>\n";
-    if (this.data.def || this.data.def === null) { xml += "<default>" + SQL.escape(this.data.def === null ? "NULL" : this.data.def) + "</default>"; }
+    if (this.data.def || this.data.def === null) {
+        let value = this.data.def === null ? "NULL" : this.data.def;
+        const quote = elm.getAttribute("quote");
+        if (quote && value !== "CURRENT_TIMESTAMP") { value = quote + value + quote; }
+        xml += "<default>" + SQL.escape(value) + "</default>";
+    }
     for (let relation of this.relations) {
         if (relation.row2 !== this) { continue; }
         xml += '<relation table="' + relation.row1.owner.getTitle() + '" row="' + relation.row1.getTitle() + (relation.name ? '" name="' + SQL.escape(relation.name).replace(/"/g, "&quot;") : "") + '" />\n';
@@ -410,7 +416,11 @@ SQL.Row.prototype.fromXML = function (node) {
         }
     }
     const defaultValue = node.getElementsByTagName("default")[0];
-    if (defaultValue && defaultValue.firstChild) { obj.def = defaultValue.firstChild.nodeValue; }
+    if (defaultValue && defaultValue.firstChild) {
+        obj.def = defaultValue.firstChild.nodeValue;
+        const quote = window.DATATYPES.getElementsByTagName("type")[obj.type].getAttribute("quote");
+        if (quote && obj.def.length >= quote.length * 2 && obj.def.indexOf(quote) === 0 && obj.def.lastIndexOf(quote) === obj.def.length - quote.length) { obj.def = obj.def.slice(quote.length, -quote.length); }
+    }
     this.update(obj);
     this.setTitle(node.getAttribute("name"));
 };

--- a/WwwSqlDesigner/wwwroot/js/row.js
+++ b/WwwSqlDesigner/wwwroot/js/row.js
@@ -391,7 +391,7 @@ SQL.Row.prototype.toXML = function () {
     if (this.data.def || this.data.def === null) {
         let value = this.data.def === null ? "NULL" : this.data.def;
         const quote = elm.getAttribute("quote");
-        if (quote && value !== "CURRENT_TIMESTAMP") { value = quote + value + quote; }
+        if (quote && this.data.def !== null && value !== "CURRENT_TIMESTAMP") { value = quote + value + quote; }
         xml += "<default>" + SQL.escape(value) + "</default>";
     }
     for (let relation of this.relations) {

--- a/WwwSqlDesigner/wwwroot/js/wwwsqldesigner.js
+++ b/WwwSqlDesigner/wwwroot/js/wwwsqldesigner.js
@@ -357,12 +357,13 @@ SQL.Designer.prototype.preparePortableImport = function (node) {
     }
     if (unknown.length) {
         const names = unknown.map(function (item) { return item.row.getAttribute("name") + " (" + item.original + ")"; }).join(", ");
-        const replacement = prompt("Choose a portable datatype for unsupported columns: " + names + "\nAvailable: " + SQL.PortableTypes.tokens.join(", "), "string");
-        const chosen = SQL.PortableTypes.canonical(replacement || "");
-        if (!chosen || chosen.facets) { return null; }
-        unknown.forEach(function (item) { item.datatype.textContent = chosen.kind; });
-    }
-    copy.setAttribute("format", SQL.PortableTypes.format);
+        for (const item of unknown) {
+            const replacement = prompt("Unsupported columns: " + names + "\nChoose a portable datatype for " + item.row.getAttribute("name") + " (" + item.original + ").\nAvailable: " + SQL.PortableTypes.tokens.join(", "), "string");
+            const chosen = SQL.PortableTypes.canonical(replacement || "");
+            if (!chosen || chosen.facets) { return null; }
+            item.datatype.textContent = chosen.kind;
+        }
+    }    copy.setAttribute("format", SQL.PortableTypes.format);
     return copy;
 };
 

--- a/WwwSqlDesigner/wwwroot/js/wwwsqldesigner.js
+++ b/WwwSqlDesigner/wwwroot/js/wwwsqldesigner.js
@@ -80,21 +80,14 @@ SQL.Designer.prototype.languageResponse = function (xmlDoc) {
 };
 
 SQL.Designer.prototype.requestDB = function () {
-    /* get datatypes file */
-    const db = this.getOption("db");
-    const bp = this.getOption("staticpath");
-    const url = bp + "db/" + db + "/datatypes.xml";
-    OZ.Request(url, this.dbResponse.bind(this), { method: "get", xml: true });
+    /* The editor always uses the canonical portable registry. */
+    this.dbResponse(null);
 };
 
 SQL.Designer.prototype.dbResponse = function (xmlDoc) {
-    if (xmlDoc) {
-        window.DATATYPES = xmlDoc.documentElement;
-    }
+    window.DATATYPES = SQL.PortableTypes.registry();
     this.flag--;
-    if (!this.flag) {
-        this.init2();
-    }
+    if (!this.flag) { this.init2(); }
 };
 
 SQL.Designer.prototype.applyStyle = function () {
@@ -336,89 +329,67 @@ SQL.Designer.prototype.findNamedTable = function (name) {
 };
 
 SQL.Designer.prototype.toXML = function (recordSave) {
-    if (recordSave) {
-        this.legend.prepareForSave();
-    }
+    if (recordSave) { this.legend.prepareForSave(); }
     let xml = '<?xml version="1.0" encoding="utf-8" ?>\n';
     xml += "<!-- SQL XML created by WWW SQL Designer, https://github.com/ondras/wwwsqldesigner/ -->\n";
-    xml += "<sql>\n";
-    xml += this.legend.toXML();
-
-    /* serialize datatypes */
-    if (window.XMLSerializer) {
-        const s = new XMLSerializer();
-        xml += s.serializeToString(window.DATATYPES);
-    } else if (window.DATATYPES.xml) {
-        xml += window.DATATYPES.xml;
-    } else {
-        alert(_("errorxml") + ": " + e.message);
-    }
-
-    for (let table of this.tables) {
-        xml += table.toXML();
-    }
+    xml += '<sql format="portable-v1">\n' + this.legend.toXML();
+    xml += new XMLSerializer().serializeToString(SQL.PortableTypes.registry());
+    for (let table of this.tables) { xml += table.toXML(); }
     xml += "</sql>\n";
-    if (recordSave) {
-        this.legend.rememberSaved(xml);
-    }
+    if (recordSave) { this.legend.rememberSaved(xml); }
     return xml;
 };
 
-SQL.Designer.prototype.fromXML = function (node) {
-    this.clearTables();
-    const legends = node.getElementsByTagName("legend");
-    this.legend.fromXML(legends.length ? legends[0] : null);
-    const types = node.getElementsByTagName("datatypes");
-    if (types.length) {
-        window.DATATYPES = types[0];
+SQL.Designer.prototype.preparePortableImport = function (node) {
+    const copy = node.cloneNode(true);
+    const types = copy.getElementsByTagName("datatypes");
+    const currentDb = window.DATATYPES.getAttribute("db");
+    const sourceDb = types.length ? types[0].getAttribute("db") : (currentDb === "portable" ? this.getOption("db") : currentDb);
+    const isPortable = copy.getAttribute("format") === SQL.PortableTypes.format || (sourceDb || "").toLowerCase() === "portable";
+    const unknown = [];
+    for (const row of copy.getElementsByTagName("row")) {
+        const datatype = row.getElementsByTagName("datatype")[0];
+        if (!datatype) { continue; }
+        const original = datatype.textContent.trim();
+        let type = isPortable ? SQL.PortableTypes.canonical(original) : SQL.PortableTypes.source(sourceDb, original);
+        if (!type) { unknown.push({ row: row, datatype: datatype, original: original }); }
+        else { datatype.textContent = SQL.PortableTypes.formatToken(type); }
     }
-    const tables = node.getElementsByTagName("table");
-    for (let table of tables) {
-        const t = this.addTable("", 0, 0);
-        t.fromXML(table);
+    if (unknown.length) {
+        const names = unknown.map(function (item) { return item.row.getAttribute("name") + " (" + item.original + ")"; }).join(", ");
+        const replacement = prompt("Choose a portable datatype for unsupported columns: " + names + "\nAvailable: " + SQL.PortableTypes.tokens.join(", "), "string");
+        const chosen = SQL.PortableTypes.canonical(replacement || "");
+        if (!chosen || chosen.facets) { return null; }
+        unknown.forEach(function (item) { item.datatype.textContent = chosen.kind; });
     }
-
-    for (let table of this.tables) {
-        /* ff one-pixel shift hack */
-        table.select();
-        table.deselect();
-    }
-
-    /* relations */
-    const rs = node.getElementsByTagName("relation");
-    for (let rel of rs) {
-        let tname = rel.getAttribute("table");
-        let rname = rel.getAttribute("row");
-
-        const t1 = this.findNamedTable(tname);
-        if (!t1) {
-            continue;
-        }
-        const r1 = t1.findNamedRow(rname);
-        if (!r1) {
-            continue;
-        }
-
-        tname = rel.parentNode.parentNode.getAttribute("name");
-        rname = rel.parentNode.getAttribute("name");
-        const t2 = this.findNamedTable(tname);
-        if (!t2) {
-            continue;
-        }
-        const r2 = t2.findNamedRow(rname);
-        if (!r2) {
-            continue;
-        }
-
-        const relation = this.addRelation(r1, r2);
-        relation.name = rel.getAttribute("name") || "";
-        relation.redraw();
-    }
-
-    this.sync();
-    this.legend.rememberSaved(this.toXML());
+    copy.setAttribute("format", SQL.PortableTypes.format);
+    return copy;
 };
 
+SQL.Designer.prototype.fromXML = function (node) {
+    const portable = this.preparePortableImport(node);
+    if (!portable) { return false; }
+    this.clearTables();
+    window.DATATYPES = SQL.PortableTypes.registry();
+    this.typeIndex = false;
+    this.fkTypeFor = false;
+    const legends = portable.getElementsByTagName("legend");
+    this.legend.fromXML(legends.length ? legends[0] : null);
+    const tables = portable.getElementsByTagName("table");
+    for (let table of tables) { const t = this.addTable("", 0, 0); t.fromXML(table); }
+    for (let table of this.tables) { table.select(); table.deselect(); }
+    const rs = portable.getElementsByTagName("relation");
+    for (let rel of rs) {
+        let t1 = this.findNamedTable(rel.getAttribute("table"));
+        let r1 = t1 && t1.findNamedRow(rel.getAttribute("row"));
+        let t2 = this.findNamedTable(rel.parentNode.parentNode.getAttribute("name"));
+        let r2 = t2 && t2.findNamedRow(rel.parentNode.getAttribute("name"));
+        if (r1 && r2) { const relation = this.addRelation(r1, r2); relation.name = rel.getAttribute("name") || ""; relation.redraw(); }
+    }
+    this.sync();
+    this.legend.rememberSaved(this.toXML());
+    return true;
+};
 SQL.Designer.prototype.setTitle = function (t) {
     document.title = this.title + (t ? " - " + t : "");
 };


### PR DESCRIPTION
## Summary
- Add portable column metadata alongside legacy XML datatypes.
- Classify common SQL Server and PostgreSQL types while preserving native details.
- Keep current editor and export behaviour unchanged as a migration foundation.

## Validation
- Focused Playwright regression suite: 6 passed.