### PR TITLE
AB#34002 Improve the foreign key relationship naming control

### DIFF
--- a/WwwSqlDesigner.Tests/Playwright/tests/relationship-names.spec.mjs
+++ b/WwwSqlDesigner.Tests/Playwright/tests/relationship-names.spec.mjs
@@ -20,16 +20,51 @@ test("names, persists, clears, and safely renders a relationship label", async (
     const input = page.locator("input.relation-name-input");
     await expect(input).toBeVisible();
     await expect(input).toHaveValue("");
-    await expect(input).toHaveAttribute("placeholder", "+");
-    await expect(page.locator("svg .relation-handle")).toHaveCSS("width", "16px");
-    await expect(page.locator("svg .relation-handle")).toHaveCSS("height", "16px");
-    await expect(page.locator("svg .relation-handle")).toHaveAttribute("x");
-    await expect(page.locator("svg .relation-handle")).toHaveAttribute("y");
+    await expect(input).not.toHaveAttribute("placeholder", "+");
+    await expect(input).toHaveCSS("position", "absolute");
+    await expect(input).toHaveCSS("z-index", "2");
+    await expect(input).toHaveCSS("width", "24px");
+    await expect(input).toHaveCSS("height", "24px");
+    const handle = page.locator("svg .relation-handle");
+    await expect(handle).toHaveCSS("width", "10px");
+    await expect(handle).toHaveCSS("height", "10px");
+    await expect(handle).toHaveAttribute("rx", "5");
+    await expect(handle).toHaveAttribute("ry", "5");
+    await expect(handle).toHaveAttribute("x");
+    await expect(handle).toHaveAttribute("y");
+
+    const inputBounds = await input.boundingBox();
+    const handleBounds = await handle.boundingBox();
+    expect(inputBounds).not.toBeNull();
+    expect(handleBounds).not.toBeNull();
+    const inputCenter = {
+        x: inputBounds.x + inputBounds.width / 2,
+        y: inputBounds.y + inputBounds.height / 2,
+    };
+    const handleCenter = {
+        x: handleBounds.x + handleBounds.width / 2,
+        y: handleBounds.y + handleBounds.height / 2,
+    };
+    expect(Math.abs(inputCenter.x - handleCenter.x)).toBeLessThan(1);
+    expect(Math.abs(inputCenter.y - handleCenter.y)).toBeLessThan(1);
+
+    await input.hover();
+    await expect(handle).toHaveClass(/relation-control-transitioning/);
+    await expect(input).toHaveClass(/relation-control-transitioning/);
+    await expect(handle).toHaveCSS("transition-property", /border-radius.*rx.*ry/);
+    await expect(handle).toHaveCSS("width", "16px");
+    await expect(handle).toHaveCSS("height", "16px");
+    await expect(input).toHaveCSS("width", "24px");
+    await expect(input).toHaveCSS("height", "24px");
+    await expect(handle).toHaveAttribute("rx", "6");
+    await expect(handle).toHaveAttribute("ry", "6");
 
     await input.click();
     await expect(input).toBeVisible();
     await expect(input).toBeFocused();
     await expect(input).toHaveCSS("width", "24px");
+    await expect(handle).toHaveAttribute("rx", "6");
+    await expect(handle).toHaveAttribute("ry", "6");
     await input.fill("  has <img src=x>  ");
     await input.press("Enter");
     await expect(input).not.toBeFocused();
@@ -121,8 +156,18 @@ test("relationship labels render in non-SVG mode and do not affect exports", asy
     expect(namedSql).toBe(unnamedSql);
     expect(namedEf).toBe(unnamedEf);
 
-    await page.evaluate(() => d.setOption("vector", false));
+    await page.evaluate(() => d.setOption("vector", ""));
     await page.reload();
+    await loadModel(page, unnamedModel);
+    const nonVectorInput = page.locator("#area input.relation-name-input");
+    const nonVectorHandle = page.locator("#area .relation-handle");
+    await expect(nonVectorInput).toHaveCSS("width", "24px");
+    await expect(nonVectorInput).toHaveCSS("height", "24px");
+    await expect(nonVectorHandle).toHaveCSS("border-radius", "50%");
+    await nonVectorInput.hover();
+    await expect(nonVectorHandle).toHaveCSS("transition-property", /border-radius.*rx.*ry/);
+    await expect(nonVectorHandle).not.toHaveCSS("border-radius", "50%");
+
     await loadModel(page, unnamedModel.replace('row="Id" />', 'row="Id" name="has" />'));
     await expect(page.locator("#area .relation-handle")).toBeVisible();
     await expect(page.locator("#area input.relation-name-input")).toHaveValue("has");

--- a/WwwSqlDesigner/wwwroot/js/relation.js
+++ b/WwwSqlDesigner/wwwroot/js/relation.js
@@ -10,6 +10,7 @@ SQL.Relation = function (owner, row1, row2) {
     this.highlighted = null;
     this.name = "";
     this.editing = false;
+    this.controlHovered = false;
     this.editingWidth = 0;
     this.transitionTimeout = null;
     SQL.Visual.apply(this);
@@ -96,7 +97,6 @@ SQL.Relation = function (owner, row1, row2) {
     this.dom.input.setAttribute("class", "relation-name-input");
     this.dom.input.setAttribute("aria-label", _("relationname"));
     this.dom.input.setAttribute("autocomplete", "off");
-    this.dom.input.setAttribute("placeholder", "+");
     this.dom.input.readOnly = true;
     this.owner.dom.container.appendChild(this.dom.input);
 
@@ -105,6 +105,8 @@ SQL.Relation = function (owner, row1, row2) {
     this.dom.input.addEventListener("blur", this.finishName.bind(this, false));
     this.dom.input.addEventListener("input", this.resizeName.bind(this));
     this.dom.input.addEventListener("keydown", this.keydownName.bind(this));
+    this.dom.input.addEventListener("mouseenter", this.hoverControl.bind(this, true));
+    this.dom.input.addEventListener("mouseleave", this.hoverControl.bind(this, false));
     this.outsideClick = this.clickAway.bind(this);
     this.redraw();
 };
@@ -178,6 +180,15 @@ SQL.Relation.prototype.selectName = function () {
     }
 };
 
+SQL.Relation.prototype.hoverControl = function (hovered) {
+    if (this.controlHovered === hovered) {
+        return;
+    }
+    this.transitionControl();
+    this.controlHovered = hovered;
+    this.redraw();
+};
+
 SQL.Relation.prototype.keydownName = function (e) {
     if (!this.editing && (e.key === "Enter" || e.key === " ")) {
         this.editName(e);
@@ -249,31 +260,37 @@ SQL.Relation.prototype.redrawControl = function (x, y) {
     this.labelPosition = [x, y];
     const hasName = !!this.name;
     const editing = this.editing;
-    const handleSize = hasName || editing ? 24 : 16;
+    const compact = !hasName && !editing && !this.controlHovered;
+    const handleSize = hasName || editing ? 24 : (compact ? 10 : 16);
     const pointX = x;
     const pointY = y;
     const controlWidth = editing
         ? this.editingWidth
-        : (hasName ? this.measureNameWidth(this.name) + 16 : 16);
+        : (hasName ? this.measureNameWidth(this.name) + 16 : handleSize);
+    const inputWidth = editing ? controlWidth : Math.max(24, controlWidth);
+    const inputHeight = Math.max(24, handleSize);
     if (this.owner.vector) {
         this.dom.handle.setAttribute("x", pointX - controlWidth / 2);
         this.dom.handle.setAttribute("y", pointY - handleSize / 2);
         this.dom.handle.setAttribute("width", controlWidth);
         this.dom.handle.setAttribute("height", handleSize);
+        this.dom.handle.setAttribute("rx", compact ? handleSize / 2 : 6);
+        this.dom.handle.setAttribute("ry", compact ? handleSize / 2 : 6);
     } else {
         this.dom.handle.style.left = pointX - controlWidth / 2 + "px";
         this.dom.handle.style.top = pointY - handleSize / 2 + "px";
         this.dom.handle.style.width = controlWidth + "px";
         this.dom.handle.style.height = handleSize + "px";
+        this.dom.handle.style.borderRadius = compact ? "50%" : "";
     }
     if (!editing) {
         this.dom.input.value = this.name;
     }
     this.dom.input.readOnly = !editing;
-    this.dom.input.style.left = pointX - controlWidth / 2 + "px";
-    this.dom.input.style.top = pointY - handleSize / 2 + "px";
-    this.dom.input.style.width = controlWidth + "px";
-    this.dom.input.style.height = handleSize + "px";
+    this.dom.input.style.left = pointX - inputWidth / 2 + "px";
+    this.dom.input.style.top = pointY - inputHeight / 2 + "px";
+    this.dom.input.style.width = inputWidth + "px";
+    this.dom.input.style.height = inputHeight + "px";
     this.dom.input.style.visibility = "";
 };
 

--- a/WwwSqlDesigner/wwwroot/styles/material-inspired.css
+++ b/WwwSqlDesigner/wwwroot/styles/material-inspired.css
@@ -713,6 +713,8 @@ label, input, select {
 .diagram-legend-timestamp > span.empty {
     opacity: .7;
     font-style: italic;
+}
+
 .relation-handle {
     background-color: #fff;
     border-radius: 2px;
@@ -725,7 +727,7 @@ label, input, select {
 }
 
 .relation-handle.relation-control-transitioning {
-    transition: left 120ms ease-out, top 120ms ease-out, x 120ms ease-out, y 120ms ease-out, width 120ms ease-out, height 120ms ease-out;
+    transition: left 120ms ease-out, top 120ms ease-out, x 120ms ease-out, y 120ms ease-out, width 120ms ease-out, height 120ms ease-out, border-radius 120ms ease-out, rx 120ms ease-out, ry 120ms ease-out;
 }
 
 input.relation-name-input {

--- a/WwwSqlDesigner/wwwroot/styles/original.css
+++ b/WwwSqlDesigner/wwwroot/styles/original.css
@@ -381,6 +381,8 @@ label, input, select {
 .diagram-legend-timestamp > span.empty {
     opacity: .7;
     font-style: italic;
+}
+
 .relation-handle {
     background-color: #fff;
     border-radius: 3px;
@@ -393,7 +395,7 @@ label, input, select {
 }
 
 .relation-handle.relation-control-transitioning {
-    transition: left 120ms ease-out, top 120ms ease-out, x 120ms ease-out, y 120ms ease-out, width 120ms ease-out, height 120ms ease-out;
+    transition: left 120ms ease-out, top 120ms ease-out, x 120ms ease-out, y 120ms ease-out, width 120ms ease-out, height 120ms ease-out, border-radius 120ms ease-out, rx 120ms ease-out, ry 120ms ease-out;
 }
 
 input.relation-name-input {


### PR DESCRIPTION
## Summary
- restore relationship-control styling broken by malformed adjacent CSS
- replace the unnamed plus control with an animated circle-to-square-to-input interaction
- cover SVG and non-SVG positioning, shape transitions, persistence, and multiple relationships

## Validation
- npm test -- tests/relationship-names.spec.mjs (3 passed)
- git diff --check