### PR TITLE
AB#13221 Polish export target selection

### DIFF
--- a/WwwSqlDesigner.Tests/Playwright/tests/portable-schema.spec.mjs
+++ b/WwwSqlDesigner.Tests/Playwright/tests/portable-schema.spec.mjs
@@ -35,6 +35,14 @@ test("imports specialized and unknown legacy types without a prompt", async ({ p
     await expect(page.locator("#iostatus")).toBeHidden();
 });
 
+test("uses the MSSQL fallback for metadata-free legacy XML", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForFunction(() => typeof d !== "undefined" && d.io);
+    await page.evaluate(() => d.setOption("db", "mysql"));
+    await load(page, '<sql><table name="Legacy"><row name="VersionStamp" null="0"><datatype>timestamp</datatype></row></table></sql>');
+    expect(await page.evaluate(() => d.toXML())).toContain("<datatype>binary</datatype>");
+});
+
 test("maps every bundled source dialect deterministically", async ({ page }) => {
     await page.goto("/");
     const cases = [["mssql", "timestamp", "binary"], ["postgresql", "interval", "text"], ["mysql", "enum", "string"], ["sqlite", "none", "text"], ["oracle", "urowid", "string"], ["cubrid", "set", "text"], ["vfp9", "currency", "decimal"], ["sqlalchemy", "sa.Interval", "text"], ["web2py", "password", "string"]];

--- a/WwwSqlDesigner.Tests/Playwright/tests/portable-schema.spec.mjs
+++ b/WwwSqlDesigner.Tests/Playwright/tests/portable-schema.spec.mjs
@@ -98,8 +98,24 @@ test("preserves defaults and selected target UI behavior", async ({ page }) => {
     expect(saved).toContain("<default>'hello'</default>");
     expect(saved).toContain("<default>12.50</default>");
     await page.locator("#saveload").click();
+    await expect(page.locator("#optiondb")).toHaveCount(0);
+    await expect(page.locator("#exporttarget option")).toHaveText([
+        "Microsoft SQL Server",
+        "PostgreSQL",
+        "MySQL",
+        "SQLite",
+        "Oracle",
+        "CUBRID",
+        "Visual FoxPro 9",
+        "SQLAlchemy",
+        "web2py",
+        "Entity Framework 8",
+    ]);
     await page.locator("#exporttarget").selectOption("postgresql");
-    await expect(page.locator("#clientsql")).toHaveValue(/postgresql/);
+    await expect(page.locator("#clientsql")).toHaveValue(/PostgreSQL/);
+    expect(await page.evaluate(() => d.getOption("lastExportTarget"))).toBe("postgresql");
+    await page.evaluate(() => d.io.click());
+    await expect(page.locator("#exporttarget")).toHaveValue("postgresql");
     expect(await page.evaluate(() => d.io.getExportXml("postgresql").xml)).toContain("varchar(20)");
 });
 
@@ -158,6 +174,39 @@ test("sends sharing grants as JSON", async ({ page }) => {
     await page.locator("#servershare").click();
     await expect.poll(() => request && request.headers()["content-type"]).toBe("application/json");
     expect(request.postData()).toBe(JSON.stringify({ targetType: "User", targetId: "abc", permission: "View" }));
+});
+
+test("falls back to MSSQL when the saved export target is unavailable", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForFunction(() => typeof d !== "undefined" && d.io);
+    await page.evaluate(() => d.setOption("lastExportTarget", "removed-target"));
+    await page.locator("#saveload").click();
+    await expect(page.locator("#exporttarget")).toHaveValue("mssql");
+});
+
+test("runs every bundled export stylesheet against a portable model", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForFunction(() => typeof d !== "undefined" && d.io);
+    await load(page, '<sql format="portable-v1"><datatypes db="portable" /><table name="Entry"><row name="Id" null="0"><datatype>integer</datatype></row><key type="PRIMARY"><part>Id</part></key></table></sql>');
+    const results = await page.evaluate(async () => {
+        const output = {};
+        for (const target of CONFIG.EXPORT_TARGETS) {
+            const response = await fetch("db/" + target.id + "/output.xsl");
+            if (!response.ok) {
+                output[target.id] = "";
+                continue;
+            }
+            output[target.id] = d.io.transformEf(
+                await response.text(),
+                d.io.getExportXml(target.id).xml,
+                target.id === "ef"
+            );
+        }
+        return output;
+    });
+    for (const [target, output] of Object.entries(results)) {
+        expect(output, target + " stylesheet output").not.toBe("");
+    }
 });
 
 test("preserves SQL NULL defaults and normalizes portable token case", async ({ page }) => {

--- a/WwwSqlDesigner/wwwroot/index.html
+++ b/WwwSqlDesigner/wwwroot/index.html
@@ -106,14 +106,6 @@
                     </td>
                 </tr>
                 <tr>
-                    <td>* <label id="db" for="optiondb"></label></td>
-                    <td>
-                        <select id="optiondb">
-                            <option></option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
                     <td><label id="efnamespace" for="optionefnamespace">EF namespace</label></td>
                     <td><input type="text" size="32" id="optionefnamespace" /></td>
                 </tr>

--- a/WwwSqlDesigner/wwwroot/js/config.js
+++ b/WwwSqlDesigner/wwwroot/js/config.js
@@ -1,16 +1,15 @@
 const CONFIG = {
-    AVAILABLE_DBS: [
-        "mysql",
-        "sqlite",
-        "web2py",
-        "mssql",
-        "postgresql",
-        "oracle",
-        "sqlalchemy",
-        "vfp9",
-        "cubrid",
-        "web2py",
-        "ef"
+    EXPORT_TARGETS: [
+        { id: "mssql", label: "Microsoft SQL Server" },
+        { id: "postgresql", label: "PostgreSQL" },
+        { id: "mysql", label: "MySQL" },
+        { id: "sqlite", label: "SQLite" },
+        { id: "oracle", label: "Oracle" },
+        { id: "cubrid", label: "CUBRID" },
+        { id: "vfp9", label: "Visual FoxPro 9" },
+        { id: "sqlalchemy", label: "SQLAlchemy" },
+        { id: "web2py", label: "web2py" },
+        { id: "ef", label: "Entity Framework 8" }
     ],
     DEFAULT_DB: "mssql",
     EF_DEFAULT_NAMESPACE: "WwwSqlDesigner.Data",

--- a/WwwSqlDesigner/wwwroot/js/io.js
+++ b/WwwSqlDesigner/wwwroot/js/io.js
@@ -87,7 +87,7 @@ SQL.IO = function (owner) {
     OZ.Event.add(this.dom.clientload, "click", this.clientload.bind(this));
     OZ.Event.add(this.dom.clientsql, "click", this.clientsql.bind(this));
     OZ.Event.add(this.dom.statusdismiss, "click", this.hideStatus.bind(this));
-    OZ.Event.add(this.dom.exporttarget, "change", this.refreshExportTargetLabel.bind(this));
+    OZ.Event.add(this.dom.exporttarget, "change", this.changeExportTarget.bind(this));
     OZ.Event.add(this.dom.clientef, "click", this.clientef.bind(this));
     OZ.Event.add(this.dom.clientefzip, "click", this.clientefzip.bind(this));
     OZ.Event.add(this.dom.quicksave, "click", this.quicksave.bind(this));
@@ -165,13 +165,13 @@ SQL.IO.prototype.build = function () {
         }
     }
 
-    const selectedTarget = this.dom.exporttarget.value || this.owner.getOption("db");
+    const selectedTarget = this.getExportTarget();
     OZ.DOM.clear(this.dom.exporttarget);
-    for (const target of CONFIG.AVAILABLE_DBS.filter((value, index, values) => values.indexOf(value) === index)) {
+    for (const target of CONFIG.EXPORT_TARGETS) {
         const option = OZ.DOM.elm("option");
-        option.value = target;
-        option.innerHTML = target;
-        option.selected = target === selectedTarget;
+        option.value = target.id;
+        option.textContent = target.label;
+        option.selected = target.id === selectedTarget;
         this.dom.exporttarget.appendChild(option);
     }
 };
@@ -186,7 +186,12 @@ SQL.IO.prototype.click = function () {
 };
 
 SQL.IO.prototype.refreshExportTargetLabel = function () {
-    this.dom.clientsql.value = _("clientsql") + " (" + this.getExportTarget() + ")";
+    this.dom.clientsql.value = _("clientsql") + " (" + this.getExportTargetDefinition().label + ")";
+};
+
+SQL.IO.prototype.changeExportTarget = function () {
+    this.owner.setOption("lastExportTarget", this.getExportTarget());
+    this.refreshExportTargetLabel();
 };
 
 SQL.IO.prototype.parseXml = function (xml) {
@@ -395,7 +400,13 @@ SQL.IO.prototype.clientef = function () {
 };
 
 SQL.IO.prototype.getExportTarget = function () {
-    return this.dom.exporttarget.value || this.owner.getOption("db");
+    return this.getExportTargetDefinition().id;
+};
+
+SQL.IO.prototype.getExportTargetDefinition = function () {
+    const selected = this.dom.exporttarget.value || this.owner.getOption("lastExportTarget");
+    return CONFIG.EXPORT_TARGETS.find((target) => target.id === selected)
+        || CONFIG.EXPORT_TARGETS.find((target) => target.id === CONFIG.DEFAULT_DB);
 };
 
 /* Maps a serialized copy only; target selection never rewrites the editor. */

--- a/WwwSqlDesigner/wwwroot/js/options.js
+++ b/WwwSqlDesigner/wwwroot/js/options.js
@@ -13,7 +13,6 @@ SQL.Options = function (owner) {
 
 SQL.Options.prototype.build = function () {
     this.dom.optionlocale = OZ.$("optionlocale");
-    this.dom.optiondb = OZ.$("optiondb");
     this.dom.optionefnamespace = OZ.$("optionefnamespace");
     this.dom.optionefcontext = OZ.$("optionefcontext");
     this.dom.optionsnap = OZ.$("optionsnap");
@@ -26,7 +25,6 @@ SQL.Options.prototype.build = function () {
 
     let ids = [
         "language",
-        "db",
         "efnamespace",
         "efcontext",
         "snap",
@@ -54,18 +52,6 @@ SQL.Options.prototype.build = function () {
         this.dom.optionlocale.appendChild(o);
         if (this.owner.getOption("locale") == ls[i]) {
             this.dom.optionlocale.selectedIndex = i;
-        }
-    }
-
-    const dbs = CONFIG.AVAILABLE_DBS;
-    OZ.DOM.clear(this.dom.optiondb);
-    for (let i = 0; i < dbs.length; i++) {
-        const o = OZ.DOM.elm("option");
-        o.value = dbs[i];
-        o.innerHTML = dbs[i];
-        this.dom.optiondb.appendChild(o);
-        if (this.owner.getOption("db") == dbs[i]) {
-            this.dom.optiondb.selectedIndex = i;
         }
     }
 
@@ -118,7 +104,6 @@ SQL.Options.prototype.save = function () {
     }
 
     this.owner.setOption("locale", this.dom.optionlocale.value);
-    this.owner.setOption("db", this.dom.optiondb.value);
     this.owner.setOption(
         "efnamespace",
         namespace || CONFIG.EF_DEFAULT_NAMESPACE

--- a/WwwSqlDesigner/wwwroot/js/wwwsqldesigner.js
+++ b/WwwSqlDesigner/wwwroot/js/wwwsqldesigner.js
@@ -347,7 +347,7 @@ SQL.Designer.prototype.preparePortableImport = function (node) {
     const copy = node.cloneNode(true);
     const types = copy.getElementsByTagName("datatypes");
     const currentDb = window.DATATYPES.getAttribute("db");
-    const sourceDb = types.length ? types[0].getAttribute("db") : (currentDb === "portable" ? this.getOption("db") : currentDb);
+    const sourceDb = types.length ? types[0].getAttribute("db") : (currentDb === "portable" ? CONFIG.DEFAULT_DB : currentDb);
     const isPortable = copy.getAttribute("format") === SQL.PortableTypes.format || (sourceDb || "").toLowerCase() === "portable";
     const diagnostics = [];
     for (const row of copy.getElementsByTagName("row")) {

--- a/WwwSqlDesigner/wwwroot/js/wwwsqldesigner.js
+++ b/WwwSqlDesigner/wwwroot/js/wwwsqldesigner.js
@@ -226,6 +226,8 @@ SQL.Designer.prototype.getOption = function (name) {
             return CONFIG.DEFAULT_LOCALE;
         case "db":
             return CONFIG.DEFAULT_DB;
+        case "lastExportTarget":
+            return CONFIG.DEFAULT_DB;
         case "efnamespace":
             return CONFIG.EF_DEFAULT_NAMESPACE;
         case "efcontext":


### PR DESCRIPTION
## Summary

- remove the obsolete global database selector
- persist the selected export target with a safe MSSQL fallback
- use technical target labels consistently
- add browser coverage for the export-target workflow

## Validation

- Full Playwright suite: 27 passed