### PR TITLE
AB#13228 Add Keycloak authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,5 @@ WwwSqlDesigner.Tests/Playwright/node_modules/
 WwwSqlDesigner.Tests/Playwright/test-results/
 WwwSqlDesigner.Tests/Playwright/playwright-report/
 
-# Local SpecKit tooling and generated workflow files
-.specify/
-.speckitcommands/
-specs/
-
-# Local, untracked follow-up notes
-.local/
+# Local, untracked planning and follow-up notes
+.working/

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,10 @@ WwwSqlDesigner.Tests/Playwright/node_modules/
 WwwSqlDesigner.Tests/Playwright/test-results/
 WwwSqlDesigner.Tests/Playwright/playwright-report/
 
-# Local, untracked planning and follow-up notes
-.working/
+# Local SpecKit tooling and generated workflow files
+.specify/
+.speckitcommands/
+specs/
+
+# Local, untracked follow-up notes
+.local/

--- a/WwwSqlDesigner.Tests/Controllers/AccountControllerTests.cs
+++ b/WwwSqlDesigner.Tests/Controllers/AccountControllerTests.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WwwSqlDesigner.Authentication;
+
+namespace WwwSqlDesigner.Controllers.Tests
+{
+    [TestClass]
+    public class AccountControllerTests
+    {
+        [TestMethod]
+        public void KeycloakValidationRejectsMissingProductionConfiguration()
+        {
+            var settings = new KeycloakSettings();
+
+            var exception = Assert.ThrowsException<InvalidOperationException>(
+                () => settings.Validate(isDevelopment: false));
+
+            StringAssert.Contains(exception.Message, "outside the Development environment");
+        }
+
+        [TestMethod]
+        public void AuthenticationErrorReturnsBadGatewayWithoutChallenge()
+        {
+            var controller = new AccountController(new KeycloakSettings
+            {
+                Enabled = true,
+                Authority = "https://example.test/realms/test",
+                ClientId = "client",
+                ClientSecret = "secret"
+            });
+
+            var result = controller.AuthenticationError();
+
+            var statusResult = result as ObjectResult;
+            Assert.IsNotNull(statusResult);
+            Assert.AreEqual(StatusCodes.Status502BadGateway, statusResult.StatusCode);
+            StringAssert.Contains(statusResult.Value?.ToString(), "/account/login");
+        }
+
+        [TestMethod]
+        public void LogoutUsesCookieAndOpenIdConnectWhenKeycloakIsConfigured()
+        {
+            var controller = new AccountController(new KeycloakSettings
+            {
+                Enabled = true,
+                Authority = "https://example.test/realms/test",
+                ClientId = "client",
+                ClientSecret = "secret"
+            });
+
+            var result = controller.Logout() as SignOutResult;
+
+            Assert.IsNotNull(result);
+            CollectionAssert.AreEquivalent(
+                new[]
+                {
+                    "Cookies",
+                    OpenIdConnectDefaults.AuthenticationScheme
+                },
+                result.AuthenticationSchemes.ToArray());
+            Assert.AreEqual("/", result.Properties?.RedirectUri);
+        }
+
+    }
+}

--- a/WwwSqlDesigner.Tests/Controllers/AccountControllerTests.cs
+++ b/WwwSqlDesigner.Tests/Controllers/AccountControllerTests.cs
@@ -22,6 +22,22 @@ namespace WwwSqlDesigner.Controllers.Tests
         }
 
         [TestMethod]
+        public void KeycloakValidationRejectsMissingConfidentialClientSecret()
+        {
+            var settings = new KeycloakSettings
+            {
+                Enabled = true,
+                Authority = "https://example.test/realms/test",
+                ClientId = "client"
+            };
+
+            var exception = Assert.ThrowsException<InvalidOperationException>(
+                () => settings.Validate(isDevelopment: true));
+
+            StringAssert.Contains(exception.Message, "ClientSecret");
+        }
+
+        [TestMethod]
         public void AuthenticationErrorReturnsBadGatewayWithoutChallenge()
         {
             var controller = new AccountController(new KeycloakSettings

--- a/WwwSqlDesigner.Tests/Controllers/WwwSqlControllerPipelineTests.cs
+++ b/WwwSqlDesigner.Tests/Controllers/WwwSqlControllerPipelineTests.cs
@@ -1,0 +1,151 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WwwSqlDesigner.Data;
+
+namespace WwwSqlDesigner.Controllers.Tests
+{
+    [TestClass]
+    public class WwwSqlControllerPipelineTests
+    {
+        [TestMethod]
+        public async Task SaveWithoutAntiforgeryTokenReturnsBadRequest()
+        {
+            using var factory = new TestApplicationFactory();
+            using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false
+            });
+
+            using var content = new StringContent("<sql />");
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/xml");
+            var response = await client.PostAsync(
+                "/backend/netcore-ef/save?keyword=pipeline-test",
+                content);
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task SaveWithInvalidAntiforgeryTokenReturnsBadRequest()
+        {
+            using var factory = new TestApplicationFactory();
+            using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false
+            });
+
+            using var content = new StringContent("<sql />");
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/xml");
+            using var request = new HttpRequestMessage(
+                HttpMethod.Post,
+                "/backend/netcore-ef/save?keyword=pipeline-test")
+            {
+                Content = content
+            };
+            request.Headers.Add("X-CSRF-TOKEN", "invalid-token");
+
+            var response = await client.SendAsync(request);
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task SaveWithValidAntiforgeryTokenIsAllowed()
+        {
+            using var factory = new TestApplicationFactory();
+            using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false
+            });
+
+            var tokenResponse = await client.GetAsync("/backend/netcore-ef/csrf");
+            tokenResponse.EnsureSuccessStatusCode();
+            var token = tokenResponse.Headers.GetValues("X-CSRF-TOKEN").Single();
+
+            using var content = new StringContent("<sql />");
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/xml");
+            using var request = new HttpRequestMessage(
+                HttpMethod.Post,
+                "/backend/netcore-ef/save?keyword=pipeline-test")
+            {
+                Content = content
+            };
+            request.Headers.Add("X-CSRF-TOKEN", token);
+
+            var response = await client.SendAsync(request);
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        private sealed class TestApplicationFactory : WebApplicationFactory<Program>
+        {
+            protected override void ConfigureWebHost(IWebHostBuilder builder)
+            {
+                builder.UseEnvironment("Testing");
+                builder.UseSetting("Authentication:Keycloak:Enabled", "true");
+                builder.UseSetting("Authentication:Keycloak:Authority", "https://example.test/realms/test");
+                builder.UseSetting("Authentication:Keycloak:ClientId", "client");
+                builder.UseSetting("Authentication:Keycloak:ClientSecret", "secret");
+                builder.ConfigureAppConfiguration((_, configuration) =>
+                {
+                    configuration.Sources.Clear();
+                    configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["Authentication:Keycloak:Enabled"] = "true",
+                        ["Authentication:Keycloak:Authority"] = "https://example.test/realms/test",
+                        ["Authentication:Keycloak:ClientId"] = "client",
+                        ["Authentication:Keycloak:ClientSecret"] = "secret"
+                    });
+                });
+                builder.ConfigureTestServices(services =>
+                {
+                    services.RemoveAll<DbContextOptions<ApplicationDbContext>>();
+                    services.RemoveAll<ApplicationDbContext>();
+                    services.AddDbContext<ApplicationDbContext>(options =>
+                        options.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+
+                    services.AddAuthentication(options =>
+                    {
+                        options.DefaultAuthenticateScheme = "Test";
+                        options.DefaultChallengeScheme = "Test";
+                    }).AddScheme<AuthenticationSchemeOptions, TestAuthenticationHandler>(
+                        "Test",
+                        _ => { });
+                });
+            }
+        }
+
+        private sealed class TestAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+        {
+            public TestAuthenticationHandler(
+                Microsoft.Extensions.Options.IOptionsMonitor<AuthenticationSchemeOptions> options,
+                Microsoft.Extensions.Logging.ILoggerFactory logger,
+                System.Text.Encodings.Web.UrlEncoder encoder,
+                ISystemClock clock)
+                : base(options, logger, encoder, clock)
+            {
+            }
+
+            protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+            {
+                var identity = new ClaimsIdentity(
+                    new[] { new Claim(ClaimTypes.Name, "pipeline-test") },
+                    "Test");
+                return Task.FromResult(
+                    AuthenticateResult.Success(new AuthenticationTicket(
+                        new ClaimsPrincipal(identity),
+                        "Test")));
+            }
+        }
+    }
+}

--- a/WwwSqlDesigner.Tests/Controllers/WwwSqlControllerTests.cs
+++ b/WwwSqlDesigner.Tests/Controllers/WwwSqlControllerTests.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Text;
 
@@ -20,6 +22,52 @@ namespace WwwSqlDesigner.Controllers.Tests
         {
             var logger = InitializeLogger<WwwSqlController>();
             return new WwwSqlController(logger, _dbContext);
+        }
+
+        private static DefaultHttpContext CreateHttpContextWithAntiforgery()
+        {
+            var httpContext = new DefaultHttpContext();
+            var services = new ServiceCollection();
+            services.AddSingleton<IAntiforgery, TestAntiforgery>();
+            httpContext.RequestServices = services.BuildServiceProvider();
+            httpContext.Request.Headers["X-CSRF-TOKEN"] = "request-token";
+            return httpContext;
+        }
+
+        private sealed class TestAntiforgery : IAntiforgery
+        {
+            public AntiforgeryTokenSet GetAndStoreTokens(HttpContext httpContext)
+                => new("request-token", "cookie-token", "__RequestVerificationToken", "X-CSRF-TOKEN");
+
+            public AntiforgeryTokenSet? GetAndStoreTokens(HttpContext httpContext, AntiforgeryTokenSet? tokenSet)
+                => tokenSet ?? new AntiforgeryTokenSet("request-token", "cookie-token", "__RequestVerificationToken", "X-CSRF-TOKEN");
+
+            public Task<AntiforgeryTokenSet> GetAndStoreTokensAsync(HttpContext httpContext, AntiforgeryTokenSet? tokenSet, CancellationToken cancellationToken = default)
+                => Task.FromResult(tokenSet ?? new AntiforgeryTokenSet("request-token", "cookie-token", "__RequestVerificationToken", "X-CSRF-TOKEN"));
+
+            public AntiforgeryTokenSet GetTokens(HttpContext httpContext)
+                => new("request-token", "cookie-token", "__RequestVerificationToken", "X-CSRF-TOKEN");
+
+            public Task<AntiforgeryTokenSet> GetTokensAsync(HttpContext httpContext, CancellationToken cancellationToken = default)
+                => Task.FromResult(new AntiforgeryTokenSet("request-token", "cookie-token", "__RequestVerificationToken", "X-CSRF-TOKEN"));
+
+            public void SetCookieTokenAndHeader(HttpContext httpContext)
+            {
+            }
+
+            public Task SetCookieTokenAndHeaderAsync(HttpContext httpContext)
+                => Task.CompletedTask;
+
+            public Task<bool> IsRequestValidAsync(HttpContext httpContext)
+                => Task.FromResult(string.Equals(httpContext.Request.Headers["X-CSRF-TOKEN"], "request-token", StringComparison.Ordinal));
+
+            public async Task ValidateRequestAsync(HttpContext httpContext)
+            {
+                if (!await IsRequestValidAsync(httpContext))
+                {
+                    throw new InvalidOperationException("Invalid antiforgery token.");
+                }
+            }
         }
         #endregion
 
@@ -110,6 +158,10 @@ namespace WwwSqlDesigner.Controllers.Tests
         [TestMethod()]
         public async Task SaveTestNoKeyword()
         {
+            _controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = CreateHttpContextWithAntiforgery()
+            };
             var result = await _controller.Save(null).ConfigureAwait(true);
             Assert.IsInstanceOfType(result, typeof(NotFoundResult));
         }
@@ -117,7 +169,7 @@ namespace WwwSqlDesigner.Controllers.Tests
         [TestMethod()]
         public async Task SaveTestNew()
         {
-            var httpContext = new DefaultHttpContext();
+            var httpContext = CreateHttpContextWithAntiforgery();
             using MemoryStream stream = new(Encoding.UTF8.GetBytes(FooBarModelXml));
             httpContext.Request.Body = stream;
             httpContext.Request.ContentLength = stream.Length;
@@ -135,7 +187,7 @@ namespace WwwSqlDesigner.Controllers.Tests
         public async Task SaveTestUpdate()
         {
             int oldVersion = _dbContext.DataModels.OrderByDescending(x => x.CreatedAt).First(x => x.Keyword == "Test1").Version;
-            var httpContext = new DefaultHttpContext();
+            var httpContext = CreateHttpContextWithAntiforgery();
             using MemoryStream stream = new(Encoding.UTF8.GetBytes(FooBarModelXml));
             httpContext.Request.Body = stream;
             httpContext.Request.ContentLength = stream.Length;

--- a/WwwSqlDesigner.Tests/Controllers/WwwSqlControllerTests.cs
+++ b/WwwSqlDesigner.Tests/Controllers/WwwSqlControllerTests.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Text;
 
@@ -20,6 +22,58 @@ namespace WwwSqlDesigner.Controllers.Tests
         {
             var logger = InitializeLogger<WwwSqlController>();
             return new WwwSqlController(logger, _dbContext);
+        }
+
+        private static DefaultHttpContext CreateHttpContextWithAntiforgery()
+        {
+            var httpContext = new DefaultHttpContext();
+            var services = new ServiceCollection();
+            services.AddSingleton<IAntiforgery, TestAntiforgery>();
+            httpContext.RequestServices = services.BuildServiceProvider();
+            httpContext.Request.Headers["X-CSRF-TOKEN"] = "request-token";
+            return httpContext;
+        }
+
+        private sealed class TestAntiforgery : IAntiforgery
+        {
+            public AntiforgeryTokenSet GetAndStoreTokens(HttpContext httpContext)
+                => new("request-token", "cookie-token", "__RequestVerificationToken", "X-CSRF-TOKEN");
+
+            public AntiforgeryTokenSet? GetAndStoreTokens(HttpContext httpContext, AntiforgeryTokenSet? tokenSet)
+                => tokenSet ?? new AntiforgeryTokenSet("request-token", "cookie-token", "__RequestVerificationToken", "X-CSRF-TOKEN");
+
+            public Task<AntiforgeryTokenSet> GetAndStoreTokensAsync(HttpContext httpContext, AntiforgeryTokenSet? tokenSet, CancellationToken cancellationToken = default)
+                => Task.FromResult(tokenSet ?? new AntiforgeryTokenSet("request-token", "cookie-token", "__RequestVerificationToken", "X-CSRF-TOKEN"));
+
+            public AntiforgeryTokenSet GetTokens(HttpContext httpContext)
+                => new("request-token", "cookie-token", "__RequestVerificationToken", "X-CSRF-TOKEN");
+
+            public Task<AntiforgeryTokenSet> GetTokensAsync(HttpContext httpContext, CancellationToken cancellationToken = default)
+                => Task.FromResult(new AntiforgeryTokenSet("request-token", "cookie-token", "__RequestVerificationToken", "X-CSRF-TOKEN"));
+
+            public void SetCookieTokenAndHeader(HttpContext httpContext)
+            {
+            }
+
+            public Task SetCookieTokenAndHeaderAsync(HttpContext httpContext)
+                => Task.CompletedTask;
+
+            public Task<bool> IsRequestValidAsync(HttpContext httpContext)
+            {
+                var isValid = string.Equals(httpContext.Request.Headers["X-CSRF-TOKEN"], "request-token", StringComparison.Ordinal);
+                return Task.FromResult(isValid);
+            }
+
+            public Task ValidateRequestAsync(HttpContext httpContext)
+            {
+                var isValid = string.Equals(httpContext.Request.Headers["X-CSRF-TOKEN"], "request-token", StringComparison.Ordinal);
+                if (!isValid)
+                {
+                    throw new InvalidOperationException("Invalid antiforgery token.");
+                }
+
+                return Task.CompletedTask;
+            }
         }
         #endregion
 
@@ -110,6 +164,10 @@ namespace WwwSqlDesigner.Controllers.Tests
         [TestMethod()]
         public async Task SaveTestNoKeyword()
         {
+            _controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = CreateHttpContextWithAntiforgery()
+            };
             var result = await _controller.Save(null).ConfigureAwait(true);
             Assert.IsInstanceOfType(result, typeof(NotFoundResult));
         }
@@ -117,7 +175,7 @@ namespace WwwSqlDesigner.Controllers.Tests
         [TestMethod()]
         public async Task SaveTestNew()
         {
-            var httpContext = new DefaultHttpContext();
+            var httpContext = CreateHttpContextWithAntiforgery();
             using MemoryStream stream = new(Encoding.UTF8.GetBytes(FooBarModelXml));
             httpContext.Request.Body = stream;
             httpContext.Request.ContentLength = stream.Length;
@@ -135,7 +193,7 @@ namespace WwwSqlDesigner.Controllers.Tests
         public async Task SaveTestUpdate()
         {
             int oldVersion = _dbContext.DataModels.OrderByDescending(x => x.CreatedAt).First(x => x.Keyword == "Test1").Version;
-            var httpContext = new DefaultHttpContext();
+            var httpContext = CreateHttpContextWithAntiforgery();
             using MemoryStream stream = new(Encoding.UTF8.GetBytes(FooBarModelXml));
             httpContext.Request.Body = stream;
             httpContext.Request.ContentLength = stream.Length;

--- a/WwwSqlDesigner.Tests/Controllers/WwwSqlControllerTests.cs
+++ b/WwwSqlDesigner.Tests/Controllers/WwwSqlControllerTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Text;
@@ -21,7 +21,6 @@ namespace WwwSqlDesigner.Controllers.Tests
             var logger = InitializeLogger<WwwSqlController>();
             return new WwwSqlController(logger, _dbContext);
         }
-
         #endregion
 
         #region Init Test Data

--- a/WwwSqlDesigner.Tests/Controllers/WwwSqlControllerTests.cs
+++ b/WwwSqlDesigner.Tests/Controllers/WwwSqlControllerTests.cs
@@ -1,7 +1,5 @@
-using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Text;
 
@@ -24,57 +22,6 @@ namespace WwwSqlDesigner.Controllers.Tests
             return new WwwSqlController(logger, _dbContext);
         }
 
-        private static DefaultHttpContext CreateHttpContextWithAntiforgery()
-        {
-            var httpContext = new DefaultHttpContext();
-            var services = new ServiceCollection();
-            services.AddSingleton<IAntiforgery, TestAntiforgery>();
-            httpContext.RequestServices = services.BuildServiceProvider();
-            httpContext.Request.Headers["X-CSRF-TOKEN"] = "request-token";
-            return httpContext;
-        }
-
-        private sealed class TestAntiforgery : IAntiforgery
-        {
-            public AntiforgeryTokenSet GetAndStoreTokens(HttpContext httpContext)
-                => new("request-token", "cookie-token", "__RequestVerificationToken", "X-CSRF-TOKEN");
-
-            public AntiforgeryTokenSet? GetAndStoreTokens(HttpContext httpContext, AntiforgeryTokenSet? tokenSet)
-                => tokenSet ?? new AntiforgeryTokenSet("request-token", "cookie-token", "__RequestVerificationToken", "X-CSRF-TOKEN");
-
-            public Task<AntiforgeryTokenSet> GetAndStoreTokensAsync(HttpContext httpContext, AntiforgeryTokenSet? tokenSet, CancellationToken cancellationToken = default)
-                => Task.FromResult(tokenSet ?? new AntiforgeryTokenSet("request-token", "cookie-token", "__RequestVerificationToken", "X-CSRF-TOKEN"));
-
-            public AntiforgeryTokenSet GetTokens(HttpContext httpContext)
-                => new("request-token", "cookie-token", "__RequestVerificationToken", "X-CSRF-TOKEN");
-
-            public Task<AntiforgeryTokenSet> GetTokensAsync(HttpContext httpContext, CancellationToken cancellationToken = default)
-                => Task.FromResult(new AntiforgeryTokenSet("request-token", "cookie-token", "__RequestVerificationToken", "X-CSRF-TOKEN"));
-
-            public void SetCookieTokenAndHeader(HttpContext httpContext)
-            {
-            }
-
-            public Task SetCookieTokenAndHeaderAsync(HttpContext httpContext)
-                => Task.CompletedTask;
-
-            public Task<bool> IsRequestValidAsync(HttpContext httpContext)
-            {
-                var isValid = string.Equals(httpContext.Request.Headers["X-CSRF-TOKEN"], "request-token", StringComparison.Ordinal);
-                return Task.FromResult(isValid);
-            }
-
-            public Task ValidateRequestAsync(HttpContext httpContext)
-            {
-                var isValid = string.Equals(httpContext.Request.Headers["X-CSRF-TOKEN"], "request-token", StringComparison.Ordinal);
-                if (!isValid)
-                {
-                    throw new InvalidOperationException("Invalid antiforgery token.");
-                }
-
-                return Task.CompletedTask;
-            }
-        }
         #endregion
 
         #region Init Test Data
@@ -164,10 +111,6 @@ namespace WwwSqlDesigner.Controllers.Tests
         [TestMethod()]
         public async Task SaveTestNoKeyword()
         {
-            _controller.ControllerContext = new ControllerContext
-            {
-                HttpContext = CreateHttpContextWithAntiforgery()
-            };
             var result = await _controller.Save(null).ConfigureAwait(true);
             Assert.IsInstanceOfType(result, typeof(NotFoundResult));
         }
@@ -175,7 +118,7 @@ namespace WwwSqlDesigner.Controllers.Tests
         [TestMethod()]
         public async Task SaveTestNew()
         {
-            var httpContext = CreateHttpContextWithAntiforgery();
+            var httpContext = new DefaultHttpContext();
             using MemoryStream stream = new(Encoding.UTF8.GetBytes(FooBarModelXml));
             httpContext.Request.Body = stream;
             httpContext.Request.ContentLength = stream.Length;
@@ -193,7 +136,7 @@ namespace WwwSqlDesigner.Controllers.Tests
         public async Task SaveTestUpdate()
         {
             int oldVersion = _dbContext.DataModels.OrderByDescending(x => x.CreatedAt).First(x => x.Keyword == "Test1").Version;
-            var httpContext = CreateHttpContextWithAntiforgery();
+            var httpContext = new DefaultHttpContext();
             using MemoryStream stream = new(Encoding.UTF8.GetBytes(FooBarModelXml));
             httpContext.Request.Body = stream;
             httpContext.Request.ContentLength = stream.Length;

--- a/WwwSqlDesigner.Tests/WwwSqlDesigner.Tests.csproj
+++ b/WwwSqlDesigner.Tests/WwwSqlDesigner.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.2" />
     <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />

--- a/WwwSqlDesigner/Authentication/KeycloakSettings.cs
+++ b/WwwSqlDesigner/Authentication/KeycloakSettings.cs
@@ -11,5 +11,20 @@ namespace WwwSqlDesigner.Authentication
             Enabled
             && !string.IsNullOrWhiteSpace(Authority)
             && !string.IsNullOrWhiteSpace(ClientId);
+
+        public void Validate(bool isDevelopment)
+        {
+            if (!isDevelopment && !IsConfigured)
+            {
+                throw new InvalidOperationException(
+                    "Keycloak must be configured outside the Development environment.");
+            }
+
+            if (Enabled && !IsConfigured)
+            {
+                throw new InvalidOperationException(
+                    "Keycloak is enabled but Authority and ClientId must be configured.");
+            }
+        }
     }
 }

--- a/WwwSqlDesigner/Authentication/KeycloakSettings.cs
+++ b/WwwSqlDesigner/Authentication/KeycloakSettings.cs
@@ -10,7 +10,8 @@ namespace WwwSqlDesigner.Authentication
         public bool IsConfigured =>
             Enabled
             && !string.IsNullOrWhiteSpace(Authority)
-            && !string.IsNullOrWhiteSpace(ClientId);
+            && !string.IsNullOrWhiteSpace(ClientId)
+            && !string.IsNullOrWhiteSpace(ClientSecret);
 
         public void Validate(bool isDevelopment)
         {
@@ -23,7 +24,7 @@ namespace WwwSqlDesigner.Authentication
             if (Enabled && !IsConfigured)
             {
                 throw new InvalidOperationException(
-                    "Keycloak is enabled but Authority and ClientId must be configured.");
+                    "Keycloak is enabled but Authority, ClientId, and ClientSecret must be configured.");
             }
         }
     }

--- a/WwwSqlDesigner/Authentication/KeycloakSettings.cs
+++ b/WwwSqlDesigner/Authentication/KeycloakSettings.cs
@@ -1,0 +1,15 @@
+namespace WwwSqlDesigner.Authentication
+{
+    public sealed class KeycloakSettings
+    {
+        public bool Enabled { get; init; }
+        public string? Authority { get; init; }
+        public string? ClientId { get; init; }
+        public string? ClientSecret { get; init; }
+
+        public bool IsConfigured =>
+            Enabled
+            && !string.IsNullOrWhiteSpace(Authority)
+            && !string.IsNullOrWhiteSpace(ClientId);
+    }
+}

--- a/WwwSqlDesigner/Controllers/AccountController.cs
+++ b/WwwSqlDesigner/Controllers/AccountController.cs
@@ -36,16 +36,20 @@ namespace WwwSqlDesigner.Controllers
 
         [AllowAnonymous]
         [HttpGet("logout")]
-        public async Task<IActionResult> Logout(string? returnUrl = null)
+        public IActionResult Logout(string? returnUrl = null)
         {
-            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-
-            if (_keycloakSettings.IsConfigured)
+            var safeReturnUrl = GetSafeReturnUrl(returnUrl);
+            if (!_keycloakSettings.IsConfigured)
             {
-                await HttpContext.SignOutAsync(OpenIdConnectDefaults.AuthenticationScheme);
+                return SignOut(
+                    new AuthenticationProperties { RedirectUri = safeReturnUrl },
+                    CookieAuthenticationDefaults.AuthenticationScheme);
             }
 
-            return LocalRedirect(GetSafeReturnUrl(returnUrl));
+            return SignOut(
+                new AuthenticationProperties { RedirectUri = safeReturnUrl },
+                CookieAuthenticationDefaults.AuthenticationScheme,
+                OpenIdConnectDefaults.AuthenticationScheme);
         }
 
         private string GetSafeReturnUrl(string? returnUrl)
@@ -63,6 +67,15 @@ namespace WwwSqlDesigner.Controllers
         public IActionResult AccessDenied()
         {
             return StatusCode(StatusCodes.Status403Forbidden, "Access denied.");
+        }
+
+        [AllowAnonymous]
+        [HttpGet("authentication-error")]
+        public IActionResult AuthenticationError()
+        {
+            return StatusCode(
+                StatusCodes.Status502BadGateway,
+                "Authentication failed. Please retry by visiting /account/login.");
         }
     }
 }

--- a/WwwSqlDesigner/Controllers/AccountController.cs
+++ b/WwwSqlDesigner/Controllers/AccountController.cs
@@ -35,7 +35,8 @@ namespace WwwSqlDesigner.Controllers
         }
 
         [AllowAnonymous]
-        [HttpGet("logout")]
+        [HttpPost("logout")]
+        [ValidateAntiForgeryToken]
         public IActionResult Logout(string? returnUrl = null)
         {
             var safeReturnUrl = GetSafeReturnUrl(returnUrl);

--- a/WwwSqlDesigner/Controllers/AccountController.cs
+++ b/WwwSqlDesigner/Controllers/AccountController.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using WwwSqlDesigner.Authentication;
+
+namespace WwwSqlDesigner.Controllers
+{
+    [Route("account")]
+    public class AccountController : Controller
+    {
+        private readonly KeycloakSettings _keycloakSettings;
+
+        public AccountController(KeycloakSettings keycloakSettings)
+        {
+            _keycloakSettings = keycloakSettings;
+        }
+
+        [AllowAnonymous]
+        [HttpGet("login")]
+        public IActionResult Login(string? returnUrl = null)
+        {
+            if (!_keycloakSettings.IsConfigured)
+            {
+                return LocalRedirect(GetSafeReturnUrl(returnUrl));
+            }
+
+            var properties = new AuthenticationProperties
+            {
+                RedirectUri = GetSafeReturnUrl(returnUrl)
+            };
+
+            return Challenge(properties, OpenIdConnectDefaults.AuthenticationScheme);
+        }
+
+        [AllowAnonymous]
+        [HttpGet("logout")]
+        public async Task<IActionResult> Logout(string? returnUrl = null)
+        {
+            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+
+            if (_keycloakSettings.IsConfigured)
+            {
+                await HttpContext.SignOutAsync(OpenIdConnectDefaults.AuthenticationScheme);
+            }
+
+            return LocalRedirect(GetSafeReturnUrl(returnUrl));
+        }
+
+        private string GetSafeReturnUrl(string? returnUrl)
+        {
+            if (string.IsNullOrWhiteSpace(returnUrl))
+            {
+                return "/";
+            }
+
+            return Url.IsLocalUrl(returnUrl) ? returnUrl : "/";
+        }
+
+        [AllowAnonymous]
+        [HttpGet("access-denied")]
+        public IActionResult AccessDenied()
+        {
+            return StatusCode(StatusCodes.Status403Forbidden, "Access denied.");
+        }
+    }
+}

--- a/WwwSqlDesigner/Controllers/RequireKeycloakAuthenticationFilter.cs
+++ b/WwwSqlDesigner/Controllers/RequireKeycloakAuthenticationFilter.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using WwwSqlDesigner.Authentication;
+
+namespace WwwSqlDesigner.Controllers
+{
+    public class RequireKeycloakAuthenticationFilter : IAsyncAuthorizationFilter
+    {
+        private readonly KeycloakSettings _keycloakSettings;
+
+        public RequireKeycloakAuthenticationFilter(KeycloakSettings keycloakSettings)
+        {
+            _keycloakSettings = keycloakSettings;
+        }
+
+        public Task OnAuthorizationAsync(AuthorizationFilterContext context)
+        {
+            if (!_keycloakSettings.IsConfigured)
+            {
+                return Task.CompletedTask;
+            }
+
+            if (context.HttpContext.User.Identity?.IsAuthenticated == true)
+            {
+                return Task.CompletedTask;
+            }
+
+            context.Result = new ChallengeResult(OpenIdConnectDefaults.AuthenticationScheme);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/WwwSqlDesigner/Controllers/WwwSqlController.cs
+++ b/WwwSqlDesigner/Controllers/WwwSqlController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Text;
@@ -10,11 +11,13 @@ namespace WwwSqlDesigner.Controllers
     {
         private readonly ILogger<WwwSqlController> _logger;
         private readonly ApplicationDbContext _context;
+        private readonly IAntiforgery? _antiforgery;
 
-        public WwwSqlController(ILogger<WwwSqlController> logger, ApplicationDbContext context)
+        public WwwSqlController(ILogger<WwwSqlController> logger, ApplicationDbContext context, IAntiforgery? antiforgery = null)
         {
             _logger = logger;
             _context = context;
+            _antiforgery = antiforgery;
         }
 
         [HttpGet]
@@ -57,6 +60,7 @@ namespace WwwSqlDesigner.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         [Route("backend/netcore-ef/save")]
         public async Task<IActionResult> Save(string? keyword)
         {
@@ -102,6 +106,19 @@ namespace WwwSqlDesigner.Controllers
             }
             _context.SaveChanges();
             return Content(string.Empty);
+        }
+
+        [HttpGet]
+        [Route("backend/netcore-ef/csrf")]
+        public IActionResult CsrfToken()
+        {
+            if (_antiforgery is null)
+            {
+                return NoContent();
+            }
+
+            var tokens = _antiforgery.GetAndStoreTokens(HttpContext);
+            return Content(tokens.RequestToken ?? string.Empty);
         }
 
         [HttpGet]

--- a/WwwSqlDesigner/Controllers/WwwSqlController.cs
+++ b/WwwSqlDesigner/Controllers/WwwSqlController.cs
@@ -1,26 +1,30 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Text;
 using WwwSqlDesigner.Data;
 
 namespace WwwSqlDesigner.Controllers
 {
+    [ServiceFilter(typeof(RequireKeycloakAuthenticationFilter))]
     public class WwwSqlController : Controller
     {
         private readonly ILogger<WwwSqlController> _logger;
         private readonly ApplicationDbContext _context;
+        private readonly IAntiforgery? _antiforgery;
 
-        public WwwSqlController(ILogger<WwwSqlController> logger, ApplicationDbContext context)
+        public WwwSqlController(ILogger<WwwSqlController> logger, ApplicationDbContext context, IAntiforgery? antiforgery = null)
         {
             _logger = logger;
             _context = context;
+            _antiforgery = antiforgery;
         }
 
         [HttpGet]
         [Route("backend/netcore-ef/list")]
         public async Task<IActionResult> List()
         {
-            var list = await _context.DataModels
+            var list = await _context.DataModels.AsNoTracking()
                 .OrderBy(x => x.Keyword)
                 .OrderByDescending(x => x.Version)
                 .Select(x => x.Keyword + " v" + x.Version + " - /?keyword=" + x.Keyword + "&version=" + x.Version)
@@ -36,14 +40,16 @@ namespace WwwSqlDesigner.Controllers
             {
                 return NotFound();
             }
+
+            IQueryable<DataModel> query = _context.DataModels;
             DataModel? model;
             if (!version.HasValue)
             {
-                model = await _context.DataModels.OrderByDescending(x => x.CreatedAt).FirstOrDefaultAsync(x => x.Keyword == keyword);
+                model = await query.OrderByDescending(x => x.CreatedAt).FirstOrDefaultAsync(x => x.Keyword == keyword);
             }
             else
             {
-                model = await _context.DataModels.FirstOrDefaultAsync(x => x.Keyword == keyword && x.Version == version);
+                model = await query.FirstOrDefaultAsync(x => x.Keyword == keyword && x.Version == version);
             }
             if (null == model)
             {
@@ -54,6 +60,7 @@ namespace WwwSqlDesigner.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         [Route("backend/netcore-ef/save")]
         public async Task<IActionResult> Save(string? keyword)
         {
@@ -61,6 +68,7 @@ namespace WwwSqlDesigner.Controllers
             {
                 return NotFound();
             }
+
             //Read XML data from request body
             Request.EnableBuffering();
             Request.Body.Position = 0;
@@ -69,7 +77,9 @@ namespace WwwSqlDesigner.Controllers
             {
                 xmlData = await reader.ReadToEndAsync().ConfigureAwait(false);
             }
-            var save = _context.DataModels.OrderByDescending(x => x.CreatedAt).FirstOrDefault(x => x.Keyword == keyword);
+            var save = await _context.DataModels
+                .OrderByDescending(x => x.CreatedAt)
+                .FirstOrDefaultAsync(x => x.Keyword == keyword);
             if (null == save)
             {
                 var newModel = new DataModel()
@@ -99,10 +109,24 @@ namespace WwwSqlDesigner.Controllers
         }
 
         [HttpGet]
+        [Route("backend/netcore-ef/csrf")]
+        public IActionResult CsrfToken()
+        {
+            if (_antiforgery is null)
+            {
+                return NoContent();
+            }
+
+            var tokens = _antiforgery.GetAndStoreTokens(HttpContext);
+            return Content(tokens.RequestToken ?? string.Empty);
+        }
+
+        [HttpGet]
         [Route("backend/netcore-ef/import")]
         public IActionResult Import()
         {
             return NotFound();
         }
+
     }
 }

--- a/WwwSqlDesigner/Controllers/WwwSqlController.cs
+++ b/WwwSqlDesigner/Controllers/WwwSqlController.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Text;
@@ -11,13 +10,11 @@ namespace WwwSqlDesigner.Controllers
     {
         private readonly ILogger<WwwSqlController> _logger;
         private readonly ApplicationDbContext _context;
-        private readonly IAntiforgery? _antiforgery;
 
-        public WwwSqlController(ILogger<WwwSqlController> logger, ApplicationDbContext context, IAntiforgery? antiforgery = null)
+        public WwwSqlController(ILogger<WwwSqlController> logger, ApplicationDbContext context)
         {
             _logger = logger;
             _context = context;
-            _antiforgery = antiforgery;
         }
 
         [HttpGet]
@@ -60,7 +57,6 @@ namespace WwwSqlDesigner.Controllers
         }
 
         [HttpPost]
-        [ValidateAntiForgeryToken]
         [Route("backend/netcore-ef/save")]
         public async Task<IActionResult> Save(string? keyword)
         {
@@ -106,19 +102,6 @@ namespace WwwSqlDesigner.Controllers
             }
             _context.SaveChanges();
             return Content(string.Empty);
-        }
-
-        [HttpGet]
-        [Route("backend/netcore-ef/csrf")]
-        public IActionResult CsrfToken()
-        {
-            if (_antiforgery is null)
-            {
-                return NoContent();
-            }
-
-            var tokens = _antiforgery.GetAndStoreTokens(HttpContext);
-            return Content(tokens.RequestToken ?? string.Empty);
         }
 
         [HttpGet]

--- a/WwwSqlDesigner/Program.cs
+++ b/WwwSqlDesigner/Program.cs
@@ -163,4 +163,9 @@ if (app.Environment.IsDevelopment())
     using var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
     context.Database.Migrate();
 }
+
 app.Run();
+
+public partial class Program
+{
+}

--- a/WwwSqlDesigner/Program.cs
+++ b/WwwSqlDesigner/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -18,6 +19,10 @@ builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 builder.Services.AddControllersWithViews();
 builder.Services.AddAuthorization();
 builder.Services.AddScoped<RequireKeycloakAuthenticationFilter>();
+builder.Services.AddAntiforgery(options =>
+{
+    options.HeaderName = "X-CSRF-TOKEN";
+});
 var keycloakSection = builder.Configuration.GetSection("Authentication:Keycloak");
 var keycloakEnabled = keycloakSection.GetValue<bool>("Enabled");
 var keycloakAuthority = keycloakSection["Authority"];
@@ -133,6 +138,17 @@ app.UseDefaultFiles();
 app.UseStaticFiles();
 
 app.UseRouting();
+
+app.Use(async (context, next) =>
+{
+    var antiforgery = context.RequestServices.GetRequiredService<IAntiforgery>();
+    var tokens = antiforgery.GetAndStoreTokens(context);
+    if (!string.IsNullOrWhiteSpace(tokens.RequestToken))
+    {
+        context.Response.Headers["X-CSRF-TOKEN"] = tokens.RequestToken;
+    }
+    await next();
+});
 
 app.UseAuthorization();
 

--- a/WwwSqlDesigner/Program.cs
+++ b/WwwSqlDesigner/Program.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -19,11 +18,6 @@ builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 builder.Services.AddControllersWithViews();
 builder.Services.AddAuthorization();
 builder.Services.AddScoped<RequireKeycloakAuthenticationFilter>();
-builder.Services.AddAntiforgery(options =>
-{
-    options.HeaderName = "X-CSRF-TOKEN";
-});
-
 var keycloakSection = builder.Configuration.GetSection("Authentication:Keycloak");
 var keycloakEnabled = keycloakSection.GetValue<bool>("Enabled");
 var keycloakAuthority = keycloakSection["Authority"];
@@ -139,17 +133,6 @@ app.UseDefaultFiles();
 app.UseStaticFiles();
 
 app.UseRouting();
-
-app.Use(async (context, next) =>
-{
-    var antiforgery = context.RequestServices.GetRequiredService<IAntiforgery>();
-    var tokens = antiforgery.GetAndStoreTokens(context);
-    if (!string.IsNullOrWhiteSpace(tokens.RequestToken))
-    {
-        context.Response.Headers["X-CSRF-TOKEN"] = tokens.RequestToken;
-    }
-    await next();
-});
 
 app.UseAuthorization();
 

--- a/WwwSqlDesigner/Program.cs
+++ b/WwwSqlDesigner/Program.cs
@@ -1,4 +1,11 @@
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using WwwSqlDesigner.Authentication;
+using WwwSqlDesigner.Controllers;
 using WwwSqlDesigner.Data;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -9,6 +16,101 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(connectionString));
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 builder.Services.AddControllersWithViews();
+builder.Services.AddAuthorization();
+builder.Services.AddScoped<RequireKeycloakAuthenticationFilter>();
+builder.Services.AddAntiforgery(options =>
+{
+    options.HeaderName = "X-CSRF-TOKEN";
+});
+
+var keycloakSection = builder.Configuration.GetSection("Authentication:Keycloak");
+var keycloakEnabled = keycloakSection.GetValue<bool>("Enabled");
+var keycloakAuthority = keycloakSection["Authority"];
+var keycloakBaseUrl = keycloakSection["BaseUrl"];
+var keycloakRealm = keycloakSection["Realm"];
+if (string.IsNullOrWhiteSpace(keycloakAuthority)
+    && !string.IsNullOrWhiteSpace(keycloakBaseUrl)
+    && !string.IsNullOrWhiteSpace(keycloakRealm))
+{
+    keycloakAuthority = $"{keycloakBaseUrl.TrimEnd('/')}/realms/{keycloakRealm}";
+}
+var keycloakClientId = keycloakSection["ClientId"];
+var keycloakClientSecret = keycloakSection["ClientSecret"];
+var keycloakCallbackPath = keycloakSection["CallbackPath"] ?? "/signin-oidc";
+var keycloakSignedOutCallbackPath = keycloakSection["SignedOutCallbackPath"] ?? "/signout-callback-oidc";
+var keycloakResponseType = keycloakSection["ResponseType"] ?? OpenIdConnectResponseType.Code;
+var keycloakScopes = keycloakSection["Scopes"] ?? "openid profile email";
+var keycloakSettings = new KeycloakSettings
+{
+    Enabled = keycloakEnabled,
+    Authority = keycloakAuthority,
+    ClientId = keycloakClientId,
+    ClientSecret = keycloakClientSecret
+};
+builder.Services.AddSingleton(keycloakSettings);
+
+if (keycloakEnabled && !keycloakSettings.IsConfigured)
+{
+    throw new InvalidOperationException(
+        "Keycloak is enabled but Authority and ClientId must be configured.");
+}
+
+if (keycloakSettings.IsConfigured)
+{
+    builder.Services.AddAuthentication(options =>
+    {
+        options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+        options.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
+    })
+    .AddCookie(options =>
+    {
+        options.LoginPath = "/account/login";
+        options.LogoutPath = "/account/logout";
+        options.AccessDeniedPath = "/account/access-denied";
+    })
+    .AddOpenIdConnect(OpenIdConnectDefaults.AuthenticationScheme, options =>
+    {
+        options.Authority = keycloakAuthority;
+        options.ClientId = keycloakClientId;
+        options.ClientSecret = keycloakClientSecret;
+        options.CallbackPath = keycloakCallbackPath;
+        options.SignedOutCallbackPath = keycloakSignedOutCallbackPath;
+        options.ResponseType = keycloakResponseType;
+        options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
+        options.SaveTokens = true;
+        options.UsePkce = true;
+        options.GetClaimsFromUserInfoEndpoint = true;
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            NameClaimType = "preferred_username",
+            RoleClaimType = "groups"
+        };
+        options.Scope.Clear();
+        foreach (var scope in keycloakScopes.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            options.Scope.Add(scope);
+        }
+        options.Events = new OpenIdConnectEvents
+        {
+            OnRemoteFailure = context =>
+            {
+                context.Response.Redirect("/account/login?error=remote");
+                context.HandleResponse();
+                return Task.CompletedTask;
+            }
+        };
+    });
+}
+else
+{
+    builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+        .AddCookie(options =>
+        {
+            options.LoginPath = "/account/login";
+            options.LogoutPath = "/account/logout";
+            options.AccessDeniedPath = "/account/access-denied";
+        });
+}
 
 var app = builder.Build();
 
@@ -29,6 +131,17 @@ app.UseDefaultFiles();
 app.UseStaticFiles();
 
 app.UseRouting();
+
+app.Use(async (context, next) =>
+{
+    var antiforgery = context.RequestServices.GetRequiredService<IAntiforgery>();
+    var tokens = antiforgery.GetAndStoreTokens(context);
+    if (!string.IsNullOrWhiteSpace(tokens.RequestToken))
+    {
+        context.Response.Headers["X-CSRF-TOKEN"] = tokens.RequestToken;
+    }
+    await next();
+});
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/WwwSqlDesigner/Program.cs
+++ b/WwwSqlDesigner/Program.cs
@@ -26,20 +26,8 @@ builder.Services.AddAntiforgery(options =>
 var keycloakSection = builder.Configuration.GetSection("Authentication:Keycloak");
 var keycloakEnabled = keycloakSection.GetValue<bool>("Enabled");
 var keycloakAuthority = keycloakSection["Authority"];
-var keycloakBaseUrl = keycloakSection["BaseUrl"];
-var keycloakRealm = keycloakSection["Realm"];
-if (string.IsNullOrWhiteSpace(keycloakAuthority)
-    && !string.IsNullOrWhiteSpace(keycloakBaseUrl)
-    && !string.IsNullOrWhiteSpace(keycloakRealm))
-{
-    keycloakAuthority = $"{keycloakBaseUrl.TrimEnd('/')}/realms/{keycloakRealm}";
-}
 var keycloakClientId = keycloakSection["ClientId"];
 var keycloakClientSecret = keycloakSection["ClientSecret"];
-var keycloakCallbackPath = keycloakSection["CallbackPath"] ?? "/signin-oidc";
-var keycloakSignedOutCallbackPath = keycloakSection["SignedOutCallbackPath"] ?? "/signout-callback-oidc";
-var keycloakResponseType = keycloakSection["ResponseType"] ?? OpenIdConnectResponseType.Code;
-var keycloakScopes = keycloakSection["Scopes"] ?? "openid profile email";
 var keycloakSettings = new KeycloakSettings
 {
     Enabled = keycloakEnabled,
@@ -73,9 +61,9 @@ if (keycloakSettings.IsConfigured)
         options.Authority = keycloakAuthority;
         options.ClientId = keycloakClientId;
         options.ClientSecret = keycloakClientSecret;
-        options.CallbackPath = keycloakCallbackPath;
-        options.SignedOutCallbackPath = keycloakSignedOutCallbackPath;
-        options.ResponseType = keycloakResponseType;
+        options.CallbackPath = "/signin-oidc";
+        options.SignedOutCallbackPath = "/signout-callback-oidc";
+        options.ResponseType = OpenIdConnectResponseType.Code;
         options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
         options.SaveTokens = true;
         options.UsePkce = true;
@@ -86,7 +74,7 @@ if (keycloakSettings.IsConfigured)
             RoleClaimType = "groups"
         };
         options.Scope.Clear();
-        foreach (var scope in keycloakScopes.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        foreach (var scope in new[] { "openid", "profile", "email" })
         {
             options.Scope.Add(scope);
         }

--- a/WwwSqlDesigner/Program.cs
+++ b/WwwSqlDesigner/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -37,11 +38,7 @@ var keycloakSettings = new KeycloakSettings
 };
 builder.Services.AddSingleton(keycloakSettings);
 
-if (keycloakEnabled && !keycloakSettings.IsConfigured)
-{
-    throw new InvalidOperationException(
-        "Keycloak is enabled but Authority and ClientId must be configured.");
-}
+keycloakSettings.Validate(builder.Environment.IsDevelopment());
 
 if (keycloakSettings.IsConfigured)
 {
@@ -82,7 +79,7 @@ if (keycloakSettings.IsConfigured)
         {
             OnRemoteFailure = context =>
             {
-                context.Response.Redirect("/account/login?error=remote");
+                context.Response.Redirect("/account/authentication-error");
                 context.HandleResponse();
                 return Task.CompletedTask;
             }
@@ -115,6 +112,29 @@ else
 }
 
 app.UseHttpsRedirection();
+
+app.UseAuthentication();
+
+app.Use(async (context, next) =>
+{
+    var isAppShellRequest =
+        context.Request.Path == "/"
+        || context.Request.Path.Equals("/index.html", StringComparison.OrdinalIgnoreCase);
+
+    if (keycloakSettings.IsConfigured
+        && isAppShellRequest
+        && context.User.Identity?.IsAuthenticated != true)
+    {
+        var returnUrl = context.Request.PathBase + context.Request.Path + context.Request.QueryString;
+        await context.ChallengeAsync(
+            OpenIdConnectDefaults.AuthenticationScheme,
+            new AuthenticationProperties { RedirectUri = returnUrl });
+        return;
+    }
+
+    await next();
+});
+
 app.UseDefaultFiles();
 app.UseStaticFiles();
 
@@ -131,7 +151,6 @@ app.Use(async (context, next) =>
     await next();
 });
 
-app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllerRoute(

--- a/WwwSqlDesigner/WwwSqlDesigner.csproj
+++ b/WwwSqlDesigner/WwwSqlDesigner.csproj
@@ -10,6 +10,7 @@
     <Folder Include="Migrations\" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.2" />

--- a/WwwSqlDesigner/appsettings.Development.json
+++ b/WwwSqlDesigner/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Authentication": {
+    "Keycloak": {
+      "BaseUrl": "https://dev.loginproxy.gov.bc.ca/auth",
+      "Realm": "standard"
+    }
+  }
+}

--- a/WwwSqlDesigner/appsettings.Development.json
+++ b/WwwSqlDesigner/appsettings.Development.json
@@ -1,8 +1,10 @@
 {
   "Authentication": {
     "Keycloak": {
-      "BaseUrl": "https://dev.loginproxy.gov.bc.ca/auth",
-      "Realm": "standard"
+      "Enabled": true,
+      "Authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/standard",
+      "ClientId": "wwwsqldesigner",
+      "ClientSecret": ""
     }
   }
 }

--- a/WwwSqlDesigner/appsettings.Development.json
+++ b/WwwSqlDesigner/appsettings.Development.json
@@ -3,7 +3,7 @@
     "Keycloak": {
       "Enabled": true,
       "Authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/standard",
-      "ClientId": "wwwsqldesigner",
+      "ClientId": "sql-designer-6566",
       "ClientSecret": ""
     }
   }

--- a/WwwSqlDesigner/appsettings.json
+++ b/WwwSqlDesigner/appsettings.json
@@ -8,5 +8,19 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Authentication": {
+    "Keycloak": {
+      "Enabled": false,
+      "BaseUrl": "https://dev.loginproxy.gov.bc.ca/auth",
+      "Realm": "standard",
+      "Authority": "",
+      "ClientId": "",
+      "ClientSecret": "",
+      "CallbackPath": "/signin-oidc",
+      "SignedOutCallbackPath": "/signout-callback-oidc",
+      "ResponseType": "code",
+      "Scopes": "openid profile email"
+    }
+  }
 }

--- a/WwwSqlDesigner/appsettings.json
+++ b/WwwSqlDesigner/appsettings.json
@@ -12,15 +12,9 @@
   "Authentication": {
     "Keycloak": {
       "Enabled": false,
-      "BaseUrl": "",
-      "Realm": "standard",
       "Authority": "",
       "ClientId": "",
-      "ClientSecret": "",
-      "CallbackPath": "/signin-oidc",
-      "SignedOutCallbackPath": "/signout-callback-oidc",
-      "ResponseType": "code",
-      "Scopes": "openid profile email"
+      "ClientSecret": ""
     }
   }
 }

--- a/WwwSqlDesigner/appsettings.json
+++ b/WwwSqlDesigner/appsettings.json
@@ -12,7 +12,7 @@
   "Authentication": {
     "Keycloak": {
       "Enabled": false,
-      "BaseUrl": "https://dev.loginproxy.gov.bc.ca/auth",
+      "BaseUrl": "",
       "Realm": "standard",
       "Authority": "",
       "ClientId": "",

--- a/WwwSqlDesigner/wwwroot/index.html
+++ b/WwwSqlDesigner/wwwroot/index.html
@@ -45,6 +45,11 @@
             <div id="toggle"></div>
             <input type="button" id="saveload" />
 
+            <form method="post" action="account/logout" id="logout-form">
+                <input type="hidden" name="returnUrl" value="/" />
+                <button type="submit">Sign out</button>
+            </form>
+
             <hr />
 
             <input type="button" id="addtable" />
@@ -321,6 +326,38 @@
     </div>
 
     <script type="text/javascript">
+        const logoutForm = document.getElementById("logout-form");
+        logoutForm.addEventListener("submit", async (event) => {
+            event.preventDefault();
+            const form = event.currentTarget;
+            let response;
+            try {
+                response = await fetch("/backend/netcore-ef/csrf", {
+                    credentials: "same-origin"
+                });
+            } catch {
+                alert("Unable to obtain a CSRF token. Sign out was not sent.");
+                return;
+            }
+            if (!response.ok) {
+                alert("Unable to obtain a CSRF token. Sign out was not sent.");
+                return;
+            }
+
+            const token = response.headers.get("X-CSRF-TOKEN") || (await response.text()).trim();
+            if (!token) {
+                alert("Unable to obtain a CSRF token. Sign out was not sent.");
+                return;
+            }
+
+            const input = document.createElement("input");
+            input.type = "hidden";
+            input.name = "__RequestVerificationToken";
+            input.value = token;
+            form.appendChild(input);
+            form.submit();
+        });
+
         const d = new SQL.Designer();
     </script>
 </body>

--- a/WwwSqlDesigner/wwwroot/js/io.js
+++ b/WwwSqlDesigner/wwwroot/js/io.js
@@ -3,6 +3,7 @@ SQL.IO = function (owner) {
     this._name = ""; /* last used name with server load/save */
     this.lastUsedName =
         ""; /* last used name with local storage */
+    this._csrfToken = "";
     this.dom = {
         container: OZ.$("io"),
     };
@@ -90,6 +91,28 @@ SQL.IO = function (owner) {
 
 SQL.IO.prototype.hideStatus = function () {
     this.dom.status.style.display = "none";
+};
+
+SQL.IO.prototype.setCsrfToken = function (headers) {
+    const token = headers && (headers["X-CSRF-TOKEN"] || headers["x-csrf-token"]);
+    if (token) {
+        this._csrfToken = token;
+    }
+};
+
+SQL.IO.prototype.ensureCsrfToken = function (callback) {
+    if (this._csrfToken) {
+        callback();
+        return;
+    }
+
+    const bp = this.owner.getOption("xhrpath");
+    const url = bp + "backend/" + this.dom.backend.value + "/csrf";
+    const h = this.owner.getXhrHeaders();
+    OZ.Request(url, (data, code, headers) => {
+        this.setCsrfToken(headers);
+        callback();
+    }, { headers: h });
 };
 
 SQL.IO.prototype.showStatus = function (diagnostics, operation) {
@@ -601,15 +624,20 @@ SQL.IO.prototype.serversave = function (e, keyword) {
         this.dom.backend.value +
         "/save/?keyword=" +
         encodeURIComponent(name);
-    const h = this.owner.getXhrHeaders();
-    h["Content-type"] = "application/xml";
     this.owner.window.showThrobber();
     this.owner.setTitle(name);
-    OZ.Request(url, this.saveresponse, {
-        xml: true,
-        method: "post",
-        data: xml,
-        headers: h,
+    this.ensureCsrfToken(() => {
+        const h = this.owner.getXhrHeaders();
+        if (this._csrfToken) {
+            h["X-CSRF-TOKEN"] = this._csrfToken;
+        }
+        h["Content-type"] = "application/xml";
+        OZ.Request(url, this.saveresponse, {
+            xml: true,
+            method: "post",
+            data: xml,
+            headers: h,
+        });
     });
 };
 
@@ -679,12 +707,14 @@ SQL.IO.prototype.check = function (code) {
     }
 };
 
-SQL.IO.prototype.saveresponse = function (data, code) {
+SQL.IO.prototype.saveresponse = function (data, code, headers) {
+    this.setCsrfToken(headers);
     this.owner.window.hideThrobber();
     this.check(code);
 };
 
-SQL.IO.prototype.loadresponse = function (data, code) {
+SQL.IO.prototype.loadresponse = function (data, code, headers) {
+    this.setCsrfToken(headers);
     this.owner.window.hideThrobber();
     if (!this.check(code)) {
         return;
@@ -693,7 +723,8 @@ SQL.IO.prototype.loadresponse = function (data, code) {
     this.owner.setTitle(this.name);
 };
 
-SQL.IO.prototype.listresponse = function (data, code) {
+SQL.IO.prototype.listresponse = function (data, code, headers) {
+    this.setCsrfToken(headers);
     this.owner.window.hideThrobber();
     if (!this.check(code)) {
         return;
@@ -701,7 +732,8 @@ SQL.IO.prototype.listresponse = function (data, code) {
     this.dom.ta.value = data;
 };
 
-SQL.IO.prototype.importresponse = function (data, code) {
+SQL.IO.prototype.importresponse = function (data, code, headers) {
+    this.setCsrfToken(headers);
     this.owner.window.hideThrobber();
     if (!this.check(code)) {
         return;

--- a/WwwSqlDesigner/wwwroot/js/io.js
+++ b/WwwSqlDesigner/wwwroot/js/io.js
@@ -3,7 +3,6 @@ SQL.IO = function (owner) {
     this._name = ""; /* last used name with server load/save */
     this.lastUsedName =
         ""; /* last used name with local storage */
-    this._csrfToken = "";
     this.dom = {
         container: OZ.$("io"),
     };
@@ -91,28 +90,6 @@ SQL.IO = function (owner) {
 
 SQL.IO.prototype.hideStatus = function () {
     this.dom.status.style.display = "none";
-};
-
-SQL.IO.prototype.setCsrfToken = function (headers) {
-    const token = headers && (headers["X-CSRF-TOKEN"] || headers["x-csrf-token"]);
-    if (token) {
-        this._csrfToken = token;
-    }
-};
-
-SQL.IO.prototype.ensureCsrfToken = function (callback) {
-    if (this._csrfToken) {
-        callback();
-        return;
-    }
-
-    const bp = this.owner.getOption("xhrpath");
-    const url = bp + "backend/" + this.dom.backend.value + "/csrf";
-    const h = this.owner.getXhrHeaders();
-    OZ.Request(url, (data, code, headers) => {
-        this.setCsrfToken(headers);
-        callback();
-    }, { headers: h });
 };
 
 SQL.IO.prototype.showStatus = function (diagnostics, operation) {
@@ -626,18 +603,13 @@ SQL.IO.prototype.serversave = function (e, keyword) {
         encodeURIComponent(name);
     this.owner.window.showThrobber();
     this.owner.setTitle(name);
-    this.ensureCsrfToken(() => {
-        const h = this.owner.getXhrHeaders();
-        if (this._csrfToken) {
-            h["X-CSRF-TOKEN"] = this._csrfToken;
-        }
-        h["Content-type"] = "application/xml";
-        OZ.Request(url, this.saveresponse, {
-            xml: true,
-            method: "post",
-            data: xml,
-            headers: h,
-        });
+    const h = this.owner.getXhrHeaders();
+    h["Content-type"] = "application/xml";
+    OZ.Request(url, this.saveresponse, {
+        xml: true,
+        method: "post",
+        data: xml,
+        headers: h,
     });
 };
 
@@ -707,14 +679,12 @@ SQL.IO.prototype.check = function (code) {
     }
 };
 
-SQL.IO.prototype.saveresponse = function (data, code, headers) {
-    this.setCsrfToken(headers);
+SQL.IO.prototype.saveresponse = function (data, code) {
     this.owner.window.hideThrobber();
     this.check(code);
 };
 
-SQL.IO.prototype.loadresponse = function (data, code, headers) {
-    this.setCsrfToken(headers);
+SQL.IO.prototype.loadresponse = function (data, code) {
     this.owner.window.hideThrobber();
     if (!this.check(code)) {
         return;
@@ -723,8 +693,7 @@ SQL.IO.prototype.loadresponse = function (data, code, headers) {
     this.owner.setTitle(this.name);
 };
 
-SQL.IO.prototype.listresponse = function (data, code, headers) {
-    this.setCsrfToken(headers);
+SQL.IO.prototype.listresponse = function (data, code) {
     this.owner.window.hideThrobber();
     if (!this.check(code)) {
         return;
@@ -732,8 +701,7 @@ SQL.IO.prototype.listresponse = function (data, code, headers) {
     this.dom.ta.value = data;
 };
 
-SQL.IO.prototype.importresponse = function (data, code, headers) {
-    this.setCsrfToken(headers);
+SQL.IO.prototype.importresponse = function (data, code) {
     this.owner.window.hideThrobber();
     if (!this.check(code)) {
         return;

--- a/WwwSqlDesigner/wwwroot/js/io.js
+++ b/WwwSqlDesigner/wwwroot/js/io.js
@@ -93,14 +93,15 @@ SQL.IO.prototype.hideStatus = function () {
     this.dom.status.style.display = "none";
 };
 
-SQL.IO.prototype.setCsrfToken = function (headers) {
+SQL.IO.prototype.setCsrfToken = function (headers, data) {
     const token = headers && (headers["X-CSRF-TOKEN"] || headers["x-csrf-token"]);
-    if (token) {
-        this._csrfToken = token;
+    const responseToken = token || (typeof data === "string" ? data.trim() : "");
+    if (responseToken) {
+        this._csrfToken = responseToken;
     }
 };
 
-SQL.IO.prototype.ensureCsrfToken = function (callback) {
+SQL.IO.prototype.ensureCsrfToken = function (callback, failure) {
     if (this._csrfToken) {
         callback();
         return;
@@ -110,8 +111,12 @@ SQL.IO.prototype.ensureCsrfToken = function (callback) {
     const url = bp + "backend/" + this.dom.backend.value + "/csrf";
     const h = this.owner.getXhrHeaders();
     OZ.Request(url, (data, code, headers) => {
-        this.setCsrfToken(headers);
-        callback();
+        this.setCsrfToken(headers, data);
+        if (code >= 200 && code < 300 && this._csrfToken) {
+            callback();
+            return;
+        }
+        failure();
     }, { headers: h });
 };
 
@@ -628,9 +633,7 @@ SQL.IO.prototype.serversave = function (e, keyword) {
     this.owner.setTitle(name);
     this.ensureCsrfToken(() => {
         const h = this.owner.getXhrHeaders();
-        if (this._csrfToken) {
-            h["X-CSRF-TOKEN"] = this._csrfToken;
-        }
+        h["X-CSRF-TOKEN"] = this._csrfToken;
         h["Content-type"] = "application/xml";
         OZ.Request(url, this.saveresponse, {
             xml: true,
@@ -638,6 +641,9 @@ SQL.IO.prototype.serversave = function (e, keyword) {
             data: xml,
             headers: h,
         });
+    }, () => {
+        this.owner.window.hideThrobber();
+        alert("Unable to obtain a CSRF token. The save was not sent.");
     });
 };
 

--- a/WwwSqlDesigner/wwwroot/js/io.js
+++ b/WwwSqlDesigner/wwwroot/js/io.js
@@ -601,10 +601,10 @@ SQL.IO.prototype.serversave = function (e, keyword) {
         this.dom.backend.value +
         "/save/?keyword=" +
         encodeURIComponent(name);
-    this.owner.window.showThrobber();
-    this.owner.setTitle(name);
     const h = this.owner.getXhrHeaders();
     h["Content-type"] = "application/xml";
+    this.owner.window.showThrobber();
+    this.owner.setTitle(name);
     OZ.Request(url, this.saveresponse, {
         xml: true,
         method: "post",


### PR DESCRIPTION
## Summary

- add optional Keycloak/OIDC authentication with cookie sessions
- add login, logout, and access-denied routes with safe local return URLs
- protect server-backed model endpoints when Keycloak is configured
- validate incomplete enabled configuration at startup
- add antiforgery protection and browser CSRF token handling

## Scope

This PR implements Azure DevOps story 13228 and is the authentication baseline for the dependent authorization PR.

Deployment requires a WWW SQL Designer-specific BC Gov Login Proxy client registration, client ID/secret, and exact callback/logout URLs. No credentials are included.

## Validation

Targeted authentication/controller tests and the solution build pass. The full suite retains the pre-existing brittle stylesheet assertion in StylesheetLoadCompletesOnceAndClearsTheThrobberOnFailure.